### PR TITLE
refactor: optimizations for integrated gpus

### DIFF
--- a/assets/shaders/burning_effect.wgsl
+++ b/assets/shaders/burning_effect.wgsl
@@ -1,9 +1,10 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
+#import bevy_falling_sand::effects::has_effect_in_radius
+#import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct BurningSettings {
     intensity: f32,
-    _padding: f32,
 }
 
 @group(2) @binding(0) var<uniform> settings: BurningSettings;
@@ -12,19 +13,21 @@ struct BurningSettings {
 @group(2) @binding(3) var effect_data_texture: texture_2d_array<f32>;
 @group(2) @binding(4) var effect_data_sampler: sampler;
 @group(2) @binding(5) var<uniform> uv_offset: vec2<f32>;
+@group(2) @binding(6) var<uniform> quad_world_rect: vec4<f32>;
 
 @fragment
 fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
-    let wrapped_uv = fract(mesh.uv + uv_offset);
     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
-    let texel = clamp(
-        vec2<i32>(floor(wrapped_uv * vec2<f32>(tex_size))),
-        vec2<i32>(0),
-        tex_size - vec2<i32>(1),
-    );
+    let texel = quad_uv_to_world_texel(mesh.uv, quad_world_rect, tex_size, uv_offset);
 
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     let has_burning = effects.a > 0.5;
+    let halo_radius = 6;
+
+    if !has_burning && !has_effect_in_radius(effect_data_texture, 0, 3, texel, tex_size, halo_radius, 2) {
+        discard;
+    }
+
     let color = textureLoad(chunk_texture, texel, 0);
 
     if has_burning && color.a > 0.01 {
@@ -46,8 +49,8 @@ fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
         return vec4<f32>(fire_tint * brightness, color.a);
     }
 
-    let burn_radius = 6.0;
-    let r = i32(burn_radius);
+    let burn_radius = f32(halo_radius);
+    let r = halo_radius;
     var fire_weight = 0.0;
     var fire_color_accum = vec3<f32>(0.0);
 

--- a/assets/shaders/gas_effect.wgsl
+++ b/assets/shaders/gas_effect.wgsl
@@ -1,5 +1,6 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
+#import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct GasSettings {
     intensity: f32,
@@ -12,16 +13,12 @@ struct GasSettings {
 @group(2) @binding(3) var effect_data_texture: texture_2d_array<f32>;
 @group(2) @binding(4) var effect_data_sampler: sampler;
 @group(2) @binding(5) var<uniform> uv_offset: vec2<f32>;
+@group(2) @binding(6) var<uniform> quad_world_rect: vec4<f32>;
 
 @fragment
 fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
-    let wrapped_uv = fract(mesh.uv + uv_offset);
     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
-    let texel = clamp(
-        vec2<i32>(floor(wrapped_uv * vec2<f32>(tex_size))),
-        vec2<i32>(0),
-        tex_size - vec2<i32>(1),
-    );
+    let texel = quad_uv_to_world_texel(mesh.uv, quad_world_rect, tex_size, uv_offset);
 
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     if effects.g < 0.5 {

--- a/assets/shaders/glow_effect.wgsl
+++ b/assets/shaders/glow_effect.wgsl
@@ -1,5 +1,7 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
+#import bevy_falling_sand::effects::has_effect_in_radius
+#import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct GlowSettings {
     intensity: f32,
@@ -12,23 +14,29 @@ struct GlowSettings {
 @group(2) @binding(3) var effect_data_texture: texture_2d_array<f32>;
 @group(2) @binding(4) var effect_data_sampler: sampler;
 @group(2) @binding(5) var<uniform> uv_offset: vec2<f32>;
+@group(2) @binding(6) var<uniform> quad_world_rect: vec4<f32>;
 
 @fragment
 fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
-    let wrapped_uv = fract(mesh.uv + uv_offset);
     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
-    let texel = clamp(
-        vec2<i32>(floor(wrapped_uv * vec2<f32>(tex_size))),
-        vec2<i32>(0),
-        tex_size - vec2<i32>(1),
-    );
+    let texel = quad_uv_to_world_texel(mesh.uv, quad_world_rect, tex_size, uv_offset);
+
+    let color = textureLoad(chunk_texture, texel, 0);
+    if color.a < 0.01 {
+        discard;
+    }
 
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     let has_glow = effects.b > 0.5;
-    let color = textureLoad(chunk_texture, texel, 0);
+    let radius_i = i32(settings.radius);
+
+    if !has_glow && !has_effect_in_radius(effect_data_texture, 0, 2, texel, tex_size, radius_i, 4) {
+        discard;
+    }
+
     let time = globals.time;
 
-    if has_glow && color.a > 0.01 {
+    if has_glow {
         let edge_r = 12;
         var empty_count = 0.0;
         var total_count = 0.0;
@@ -51,17 +59,12 @@ fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
         return vec4<f32>(hot_color * brightness, color.a);
     }
 
-    if color.a < 0.01 {
-        discard;
-    }
-
-    let r = i32(settings.radius);
     var glow_accum = vec3<f32>(0.0);
     var total_weight = 0.0;
     var min_dist = settings.radius + 1.0;
 
-    for (var dy = -r; dy <= r; dy++) {
-        for (var dx = -r; dx <= r; dx++) {
+    for (var dy = -radius_i; dy <= radius_i; dy++) {
+        for (var dx = -radius_i; dx <= radius_i; dx++) {
             let neighbor = texel + vec2<i32>(dx, dy);
             if neighbor.x < 0 || neighbor.y < 0 || neighbor.x >= tex_size.x || neighbor.y >= tex_size.y {
                 continue;

--- a/assets/shaders/liquid_effect.wgsl
+++ b/assets/shaders/liquid_effect.wgsl
@@ -1,5 +1,6 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
+#import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct LiquidSettings {
     intensity: f32,
@@ -12,16 +13,12 @@ struct LiquidSettings {
 @group(2) @binding(3) var effect_data_texture: texture_2d_array<f32>;
 @group(2) @binding(4) var effect_data_sampler: sampler;
 @group(2) @binding(5) var<uniform> uv_offset: vec2<f32>;
+@group(2) @binding(6) var<uniform> quad_world_rect: vec4<f32>;
 
 @fragment
 fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
-    let wrapped_uv = fract(mesh.uv + uv_offset);
     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
-    let texel = clamp(
-        vec2<i32>(floor(wrapped_uv * vec2<f32>(tex_size))),
-        vec2<i32>(0),
-        tex_size - vec2<i32>(1),
-    );
+    let texel = quad_uv_to_world_texel(mesh.uv, quad_world_rect, tex_size, uv_offset);
 
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     if effects.r < 0.5 {

--- a/examples/utils/effects.rs
+++ b/examples/utils/effects.rs
@@ -160,7 +160,6 @@ pub struct GlowSettings {
 #[derive(ShaderType, Debug, Clone)]
 pub struct BurningSettings {
     pub intensity: f32,
-    pub _padding: f32,
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +178,8 @@ pub struct LiquidEffectMaterial {
     pub effect_data: Handle<Image>,
     #[uniform(5)]
     pub uv_offset: Vec2,
+    #[uniform(6)]
+    pub quad_world_rect: Vec4,
 }
 
 impl Material2d for LiquidEffectMaterial {
@@ -200,10 +201,17 @@ impl ChunkEffectMaterial for LiquidEffectMaterial {
             chunk_texture,
             effect_data,
             uv_offset: Vec2::ZERO,
+            quad_world_rect: Vec4::ZERO,
         }
     }
     fn set_uv_offset(&mut self, offset: Vec2) {
         self.uv_offset = offset;
+    }
+    fn set_quad_world_rect(&mut self, rect: Vec4) {
+        self.quad_world_rect = rect;
+    }
+    fn affected_channels() -> &'static [(usize, usize)] {
+        &[(0, 0)]
     }
 }
 
@@ -219,6 +227,8 @@ pub struct GasEffectMaterial {
     pub effect_data: Handle<Image>,
     #[uniform(5)]
     pub uv_offset: Vec2,
+    #[uniform(6)]
+    pub quad_world_rect: Vec4,
 }
 
 impl Material2d for GasEffectMaterial {
@@ -240,10 +250,20 @@ impl ChunkEffectMaterial for GasEffectMaterial {
             chunk_texture,
             effect_data,
             uv_offset: Vec2::ZERO,
+            quad_world_rect: Vec4::ZERO,
         }
     }
     fn set_uv_offset(&mut self, offset: Vec2) {
         self.uv_offset = offset;
+    }
+    fn set_quad_world_rect(&mut self, rect: Vec4) {
+        self.quad_world_rect = rect;
+    }
+    fn affected_channels() -> &'static [(usize, usize)] {
+        &[(0, 1)]
+    }
+    fn padding() -> u32 {
+        4
     }
 }
 
@@ -259,6 +279,8 @@ pub struct GlowEffectMaterial {
     pub effect_data: Handle<Image>,
     #[uniform(5)]
     pub uv_offset: Vec2,
+    #[uniform(6)]
+    pub quad_world_rect: Vec4,
 }
 
 impl Material2d for GlowEffectMaterial {
@@ -280,10 +302,20 @@ impl ChunkEffectMaterial for GlowEffectMaterial {
             chunk_texture,
             effect_data,
             uv_offset: Vec2::ZERO,
+            quad_world_rect: Vec4::ZERO,
         }
     }
     fn set_uv_offset(&mut self, offset: Vec2) {
         self.uv_offset = offset;
+    }
+    fn set_quad_world_rect(&mut self, rect: Vec4) {
+        self.quad_world_rect = rect;
+    }
+    fn affected_channels() -> &'static [(usize, usize)] {
+        &[(0, 2)]
+    }
+    fn padding() -> u32 {
+        12
     }
 }
 
@@ -299,6 +331,8 @@ pub struct BurningEffectMaterial {
     pub effect_data: Handle<Image>,
     #[uniform(5)]
     pub uv_offset: Vec2,
+    #[uniform(6)]
+    pub quad_world_rect: Vec4,
 }
 
 impl Material2d for BurningEffectMaterial {
@@ -313,17 +347,24 @@ impl Material2d for BurningEffectMaterial {
 impl ChunkEffectMaterial for BurningEffectMaterial {
     fn new(chunk_texture: Handle<Image>, effect_data: Handle<Image>) -> Self {
         Self {
-            settings: BurningSettings {
-                intensity: 1.0,
-                _padding: 0.0,
-            },
+            settings: BurningSettings { intensity: 1.0 },
             chunk_texture,
             effect_data,
             uv_offset: Vec2::ZERO,
+            quad_world_rect: Vec4::ZERO,
         }
     }
     fn set_uv_offset(&mut self, offset: Vec2) {
         self.uv_offset = offset;
+    }
+    fn set_quad_world_rect(&mut self, rect: Vec4) {
+        self.quad_world_rect = rect;
+    }
+    fn affected_channels() -> &'static [(usize, usize)] {
+        &[(0, 3)]
+    }
+    fn padding() -> u32 {
+        6
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -110,8 +110,15 @@
 //!
 //! ### Step 2 — Implement a custom material
 //!
-//! Implement [`ChunkEffectMaterial`] (which requires `Material2d`)
-//! to bind the color texture, effect data texture, and any custom uniforms your shader needs.
+//! Implement [`ChunkEffectMaterial`] (which requires `Material2d`) to bind the color
+//! texture, the effect data texture array, the UV offset uniform, the per-frame
+//! `quad_world_rect` uniform, and any custom uniforms your shader needs.
+//!
+//! Declare the `(layer, channel)` pairs the shader reads via
+//! [`ChunkEffectMaterial::affected_channels`]. Each frame the framework sizes the
+//! overlay quad to the bounding box of chunks where any of those channels has data,
+//! padded by [`ChunkEffectMaterial::padding`] texels, and hides the overlay entirely
+//! when nothing is active.
 //!
 //! ```ignore
 //! use bevy::prelude::*;
@@ -130,6 +137,8 @@
 //!     pub effect_data: Handle<Image>,
 //!     #[uniform(4)]
 //!     pub uv_offset: Vec2,
+//!     #[uniform(5)]
+//!     pub quad_world_rect: Vec4,
 //! }
 //!
 //! impl Material2d for MyEffectMaterial {
@@ -143,10 +152,24 @@
 //!
 //! impl ChunkEffectMaterial for MyEffectMaterial {
 //!     fn new(chunk_texture: Handle<Image>, effect_data: Handle<Image>) -> Self {
-//!         Self { chunk_texture, effect_data, uv_offset: Vec2::ZERO }
+//!         Self {
+//!             chunk_texture,
+//!             effect_data,
+//!             uv_offset: Vec2::ZERO,
+//!             quad_world_rect: Vec4::ZERO,
+//!         }
 //!     }
 //!     fn set_uv_offset(&mut self, offset: Vec2) {
 //!         self.uv_offset = offset;
+//!     }
+//!     fn set_quad_world_rect(&mut self, rect: Vec4) {
+//!         self.quad_world_rect = rect;
+//!     }
+//!     fn affected_channels() -> &'static [(usize, usize)] {
+//!         &[(0, 0), (0, 2), (1, 0)]
+//!     }
+//!     fn padding() -> u32 {
+//!         12 // largest neighborhood radius the shader reads
 //!     }
 //! }
 //! ```
@@ -183,32 +206,40 @@
 //!
 //! ### Step 4 — Write the WGSL shader
 //!
-//! The shader receives the color texture and the effect data texture array. Each array
-//! layer is an RGBA8 texture providing up to 4 channels. Use `textureLoad` with the
-//! array layer index to read from different layers. A shader that reads layers 0 and 1:
+//! The shader receives the color texture, the effect data texture array, the UV offset,
+//! and the `quad_world_rect` uniform that maps the local quad UV to a world texel.
+//! Import the `bevy_falling_sand::effects` helper module to map UVs to texels and to
+//! cheaply scan a neighborhood for active effect channels before any expensive work.
 //!
 //! ```wgsl
+//! #import bevy_falling_sand::effects::quad_uv_to_world_texel
+//! #import bevy_falling_sand::effects::has_effect_in_radius
+//!
 //! @group(2) @binding(0) var chunk_texture: texture_2d<f32>;
 //! @group(2) @binding(1) var chunk_sampler: sampler;
 //! @group(2) @binding(2) var effect_data: texture_2d_array<f32>;
 //! @group(2) @binding(3) var effect_sampler: sampler;
 //! @group(2) @binding(4) var<uniform> uv_offset: vec2<f32>;
+//! @group(2) @binding(5) var<uniform> quad_world_rect: vec4<f32>;
 //!
 //! @fragment
 //! fn fragment(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-//!     let wrapped_uv = fract(uv + uv_offset);
-//!     let tex_size = vec2<f32>(textureDimensions(chunk_texture, 0));
-//!     let texel = vec2<i32>(floor(wrapped_uv * tex_size));
+//!     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
+//!     let texel = quad_uv_to_world_texel(uv, quad_world_rect, tex_size, uv_offset);
+//!
+//!     // Cheap presence test before any radius loop. Discard pixels that cannot
+//!     // contribute output. `stride > 1` makes the scan sub-linear in radius.
+//!     if !has_effect_in_radius(effect_data, 0, 2, texel, tex_size, 12, 4) {
+//!         discard;
+//!     }
+//!
 //!     let color = textureLoad(chunk_texture, texel, 0);
-//!     let layer0 = textureLoad(effect_data, texel, 0, 0); // array layer 0
-//!     let layer1 = textureLoad(effect_data, texel, 1, 0); // array layer 1
+//!     let layer0 = textureLoad(effect_data, texel, 0, 0);
+//!     let layer1 = textureLoad(effect_data, texel, 1, 0);
 //!
 //!     var out = color;
-//!     // Layer 0, red channel = liquid
 //!     out = mix(out, vec4(0.2, 0.5, 1.0, 1.0) * color.a, layer0.r * 0.4);
-//!     // Layer 0, blue channel = glow
 //!     out = mix(out, vec4(1.0, 0.7, 0.3, 1.0) * color.a, layer0.b * 0.6);
-//!     // Layer 1, red channel = heat
 //!     out = mix(out, vec4(1.0, 0.2, 0.0, 1.0) * color.a, layer1.r * 0.5);
 //!     return out;
 //! }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -9,9 +9,9 @@
 //!    palette-based and gradient-based color sources with sequential or random assignment.
 //!
 //! 2. **Chunk rendering pipeline** ([`pipeline`]) — renders all particles into a single
-//!    world-sized texture using GPU compute shaders for efficient pixel updates.
-//!    An optional effect layer system overlays shader-based visual effects, which can be
-//!    accompanied by a custom shader written by the user.
+//!    world-sized texture using GPU compute shaders for efficient pixel updates. An effect
+//!    layer system overlays shader-based visual effects via user-written WGSL materials,
+//!    with overlay quads sized per frame to the active region.
 //!
 //! ## Render Pipeline Flow
 //!
@@ -26,39 +26,46 @@
 //!    and inserts [`ParticleColor`] + [`ColorIndex`] components. [`ForceColor`] overrides
 //!    the profile; [`WithColor`] restores a saved index for scene persistence.
 //!
-//! 3. **Dirty-rect collection** (`PostUpdate`):
+//! 3. **Dirty-rect collection** (`PostUpdate`, [`RenderingSystems::ChunkEffectLayerUpdate`]):
 //!    [`update_world_color_texture`](pipeline::textures) iterates dirty chunk rects and
 //!    packs `[texel_position, srgba_color]` pairs into a
 //!    [`ParticleUpdateBuffer`](pipeline::textures::ParticleUpdateBuffer). A single-pass
 //!    `update_all_effect_layers` system evaluates all registered effect layers per dirty
-//!    texel and packs into an
-//!    [`EffectUpdateBuffer`](pipeline::textures::EffectUpdateBuffer).
+//!    texel, packs into an [`EffectUpdateBuffer`](pipeline::textures::EffectUpdateBuffer),
+//!    and incrementally updates [`ChunkEffectActivity`](pipeline::textures::ChunkEffectActivity)
+//!    counters as texels transition between zero and non-zero.
 //!
-//! 4. **GPU compute dispatch** (`Render`, `RenderSystems::Queue`):
+//! 4. **Region culling** (`PostUpdate`, [`RenderingSystems::ChunkEffectRegion`]):
+//!    For each registered material, `compute_active_region` builds a bounding box over
+//!    the chunks where any of [`ChunkEffectMaterial::affected_channels`] is non-zero,
+//!    padded by [`ChunkEffectMaterial::padding`] texels. `update_effect_overlay` resizes
+//!    the material's overlay quad to that box and pushes it into the material's
+//!    `quad_world_rect` uniform — or hides the entity entirely when nothing is active.
+//!
+//! 5. **GPU compute dispatch** (`Render`, `RenderSystems::Queue`):
 //!    Extract systems copy the update buffers to the render world. Because only changed pixels are
 //!    updated, the synchronization overhead is minimal. `dispatch_chunk_compute` /
 //!    `dispatch_effect_compute` run WGSL compute shaders that scatter-write the packed updates
 //!    into the storage textures (max 65,535 × 64 = ~4M updates per dispatch).
 //!
-//! 5. **Toroidal wrapping**: The texture uses modular addressing via a texture origin
+//! 6. **Toroidal wrapping**: The texture uses modular addressing via a texture origin
 //!    resource. When the map origin shifts (infinite world scrolling),
-//!    [`handle_origin_shift`](pipeline::textures) clears unloaded chunk texels and
-//!    the material UV offset is adjusted to keep the view aligned.
+//!    [`handle_origin_shift`](pipeline::textures) clears unloaded chunk texels, zeroes
+//!    their activity counters, and adjusts the material UV offset to keep the view aligned.
 //!
-//! 6. **Effect layer system**: Extensible overlay channels registered via the
+//! 7. **Effect layer system**: Extensible overlay channels registered via the
 //!    [`ChunkEffectLayer`] trait. Each layer maps to a texture array layer index and
-//!    RGBA channel. One or more [`ChunkEffectMaterial`] shaders read the effect data
-//!    texture array to produce effects as desired. Multiple materials can be registered,
-//!    each with its own shader, stacked as separate overlay entities.
+//!    RGBA channel. Each [`ChunkEffectMaterial`] reads the effect data texture array to
+//!    produce its effect. Multiple materials can be registered, each with its own shader,
+//!    stacked as separate overlay entities.
 //!
 //! ## Custom Shaders and Effect Layers
 //!
 //! The effect layer system lets you tag particles with marker components and render them
 //! with custom WGSL shaders. Each [`ChunkEffectLayer`] maps a component to a texture array
-//! layer index and RGBA channel. One or more [`ChunkEffectMaterial`] shaders read both the
-//! color texture and the shared effect data texture array to produce visual effects.
-//!
-//! You can define your own effects and shaders for particles.
+//! layer index and RGBA channel. Each [`ChunkEffectMaterial`] reads the color texture and
+//! the shared effect data texture array to produce its effect; multiple materials can be
+//! stacked as independent overlay entities.
 //!
 //! ### Step 1 — Define marker components and effect layers
 //!

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -32,8 +32,8 @@
 //!    [`ParticleUpdateBuffer`](pipeline::textures::ParticleUpdateBuffer). A single-pass
 //!    `update_all_effect_layers` system evaluates all registered effect layers per dirty
 //!    texel, packs into an [`EffectUpdateBuffer`](pipeline::textures::EffectUpdateBuffer),
-//!    and incrementally updates [`ChunkEffectActivity`](pipeline::textures::ChunkEffectActivity)
-//!    counters as texels transition between zero and non-zero.
+//!    and incrementally updates [`ChunkEffectActivity`] counters as texels transition
+//!    between zero and non-zero.
 //!
 //! 4. **Region culling** (`PostUpdate`, [`RenderingSystems::ChunkEffectRegion`]):
 //!    For each registered material, `compute_active_region` builds a bounding box over

--- a/src/render/pipeline/mod.rs
+++ b/src/render/pipeline/mod.rs
@@ -4,9 +4,9 @@ pub mod textures;
 use bevy::prelude::*;
 
 pub use textures::{
-    ChunkEffectApp, ChunkEffectLayer, ChunkEffectMaterial, ChunkRenderingConfig,
-    ChunkRenderingPlugin, DefaultChunkEffectMaterial, WorldColorTexture, WorldEffectTexture,
-    extract_chunk_image,
+    ChunkEffectActiveRegion, ChunkEffectActivity, ChunkEffectApp, ChunkEffectLayer,
+    ChunkEffectMaterial, ChunkRenderingConfig, ChunkRenderingPlugin, DefaultChunkEffectMaterial,
+    WorldColorTexture, WorldEffectTexture, extract_chunk_image,
 };
 
 pub(super) struct RenderPipelinePlugin;

--- a/src/render/pipeline/shaders/default_chunk_effect.wgsl
+++ b/src/render/pipeline/shaders/default_chunk_effect.wgsl
@@ -1,20 +1,17 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
+#import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 @group(2) @binding(0) var chunk_texture: texture_2d<f32>;
 @group(2) @binding(1) var chunk_sampler: sampler;
 @group(2) @binding(2) var effect_data_texture: texture_2d_array<f32>;
 @group(2) @binding(3) var effect_data_sampler: sampler;
 @group(2) @binding(4) var<uniform> uv_offset: vec2<f32>;
+@group(2) @binding(5) var<uniform> quad_world_rect: vec4<f32>;
 
 @fragment
 fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
-    let wrapped_uv = fract(mesh.uv + uv_offset);
     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
-    let texel = clamp(
-        vec2<i32>(floor(wrapped_uv * vec2<f32>(tex_size))),
-        vec2<i32>(0),
-        tex_size - vec2<i32>(1),
-    );
+    let texel = quad_uv_to_world_texel(mesh.uv, quad_world_rect, tex_size, uv_offset);
 
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     let any_effect = effects.r + effects.g + effects.b + effects.a;

--- a/src/render/pipeline/shaders/effects.wgsl
+++ b/src/render/pipeline/shaders/effects.wgsl
@@ -1,0 +1,57 @@
+#define_import_path bevy_falling_sand::effects
+
+fn effect_channel(
+    effect_data: texture_2d_array<f32>,
+    layer: i32,
+    channel: i32,
+    texel: vec2<i32>,
+) -> f32 {
+    let v = textureLoad(effect_data, texel, layer, 0);
+    if channel == 0 { return v.r; }
+    if channel == 1 { return v.g; }
+    if channel == 2 { return v.b; }
+    return v.a;
+}
+
+fn has_effect_in_radius(
+    effect_data: texture_2d_array<f32>,
+    layer: i32,
+    channel: i32,
+    texel: vec2<i32>,
+    tex_size: vec2<i32>,
+    radius: i32,
+    stride: i32,
+) -> bool {
+    let s = max(stride, 1);
+    for (var dy = -radius; dy <= radius; dy = dy + s) {
+        for (var dx = -radius; dx <= radius; dx = dx + s) {
+            let n = texel + vec2<i32>(dx, dy);
+            if n.x < 0 || n.y < 0 || n.x >= tex_size.x || n.y >= tex_size.y {
+                continue;
+            }
+            if effect_channel(effect_data, layer, channel, n) > 0.5 {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Maps a fragment's local quad UV to a texel in the world effect / color texture.
+//
+// `quad_world_rect` is `(min_x, min_y, size_x, size_y)` in world coordinates, relative
+// to the current map origin (the framework subtracts the map origin before passing it).
+// `uv_offset` is the same toroidal-wrap offset used by the world-sized color sprite.
+fn quad_uv_to_world_texel(
+    uv: vec2<f32>,
+    quad_world_rect: vec4<f32>,
+    tex_size: vec2<i32>,
+    uv_offset: vec2<f32>,
+) -> vec2<i32> {
+    let tex_size_f = vec2<f32>(tex_size);
+    let world_u = (quad_world_rect.x + uv.x * quad_world_rect.z) / tex_size_f.x;
+    let world_v = 1.0 - (quad_world_rect.y + (1.0 - uv.y) * quad_world_rect.w) / tex_size_f.y;
+    let wrapped = fract(vec2<f32>(world_u, world_v) + uv_offset);
+    let texel_f = floor(wrapped * tex_size_f);
+    return clamp(vec2<i32>(texel_f), vec2<i32>(0), tex_size - vec2<i32>(1));
+}

--- a/src/render/pipeline/textures.rs
+++ b/src/render/pipeline/textures.rs
@@ -38,6 +38,7 @@ pub struct ChunkRenderingPlugin;
 
 impl Plugin for ChunkRenderingPlugin {
     fn build(&self, app: &mut App) {
+        app.init_asset::<bevy_shader::Shader>();
         bevy_shader::load_shader_library!(app, "shaders/effects.wgsl");
         bevy::asset::embedded_asset!(app, "shaders/world_color.wgsl");
 

--- a/src/render/pipeline/textures.rs
+++ b/src/render/pipeline/textures.rs
@@ -27,6 +27,7 @@ use crate::core::{
 };
 use crate::render::particle::components::ParticleColor;
 use crate::render::schedule::RenderingSystems;
+use bevy::platform::collections::HashMap;
 
 /// Plugin that enables world-texture-based particle rendering.
 ///
@@ -37,12 +38,14 @@ pub struct ChunkRenderingPlugin;
 
 impl Plugin for ChunkRenderingPlugin {
     fn build(&self, app: &mut App) {
+        bevy_shader::load_shader_library!(app, "shaders/effects.wgsl");
         bevy::asset::embedded_asset!(app, "shaders/world_color.wgsl");
 
         app.add_plugins(Material2dPlugin::<WorldColorMaterial>::default())
             .init_resource::<ChunkRenderingConfig>()
             .init_resource::<ParticleUpdateBuffer>()
             .init_resource::<EffectUpdateBuffer>()
+            .init_resource::<ChunkEffectActivity>()
             .add_systems(
                 Update,
                 (
@@ -203,11 +206,94 @@ struct EffectSystemCache {
     state: Option<
         SystemState<(
             Res<'static, ParticleMap>,
+            Res<'static, ChunkIndex>,
             Res<'static, WorldEffectShadowBuffer>,
             Query<'static, 'static, (&'static ChunkRegion, &'static ChunkDirtyState)>,
         )>,
     >,
-    dirty_entries: Vec<(usize, usize, Option<Entity>)>,
+    dirty_entries: Vec<(usize, usize, Option<Entity>, ChunkCoord)>,
+}
+
+/// Per-chunk per-channel counters tracking how many texels in each chunk currently
+/// hold a non-zero value for each `(layer, channel)` slot of the effect data texture.
+///
+/// Updated incrementally by `update_all_effect_layers` as texels transition between
+/// zero and non-zero values, and cleared per chunk when chunks unload. Region culling
+/// reads this to compute each material's draw bounds.
+#[derive(Resource, Default)]
+pub struct ChunkEffectActivity {
+    per_chunk: HashMap<ChunkCoord, Vec<u32>>,
+    slots_per_chunk: usize,
+}
+
+impl ChunkEffectActivity {
+    fn ensure_slots(&mut self, slots: usize) {
+        if self.slots_per_chunk == slots {
+            return;
+        }
+        self.slots_per_chunk = slots;
+        for counts in self.per_chunk.values_mut() {
+            counts.resize(slots, 0);
+        }
+    }
+
+    fn inc(&mut self, coord: ChunkCoord, slot: usize) {
+        let slots = self.slots_per_chunk;
+        let entry = self
+            .per_chunk
+            .entry(coord)
+            .or_insert_with(|| vec![0; slots]);
+        if slot < entry.len() {
+            entry[slot] = entry[slot].saturating_add(1);
+        }
+    }
+
+    fn dec(&mut self, coord: ChunkCoord, slot: usize) {
+        let drop_entry;
+        {
+            let Some(entry) = self.per_chunk.get_mut(&coord) else {
+                return;
+            };
+            if slot < entry.len() && entry[slot] > 0 {
+                entry[slot] -= 1;
+            }
+            drop_entry = entry.iter().all(|&c| c == 0);
+        }
+        if drop_entry {
+            self.per_chunk.remove(&coord);
+        }
+    }
+
+    fn clear_chunk(&mut self, coord: ChunkCoord) {
+        self.per_chunk.remove(&coord);
+    }
+
+    fn any_active(&self, coord: ChunkCoord, slots: &[usize]) -> bool {
+        let Some(counts) = self.per_chunk.get(&coord) else {
+            return false;
+        };
+        slots.iter().any(|&s| s < counts.len() && counts[s] > 0)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (ChunkCoord, &Vec<u32>)> {
+        self.per_chunk.iter().map(|(c, v)| (*c, v))
+    }
+}
+
+/// World-space bounding rectangle of `M`'s active region, or `None` when nothing is active.
+///
+/// Bounds the chunks where any of [`ChunkEffectMaterial::affected_channels`] currently
+/// has data, padded outward by [`ChunkEffectMaterial::padding`] texels.
+#[derive(Resource)]
+pub struct ChunkEffectActiveRegion<M: ChunkEffectMaterial>(
+    pub Option<IRect>,
+    PhantomData<fn() -> M>,
+);
+
+impl<M: ChunkEffectMaterial> Default for ChunkEffectActiveRegion<M> {
+    fn default() -> Self {
+        Self(None, PhantomData)
+    }
 }
 
 /// Trait that maps a type-level marker to an RGBA channel in the effect data texture array.
@@ -239,9 +325,24 @@ pub trait ChunkEffectLayer: Send + Sync + 'static {
 
 /// Trait for effect materials that overlay chunk images with shader-based effects.
 ///
-/// Implementors provide a constructor that takes the world color texture and
-/// the effect data texture array. The `setup_world_effect_overlay` system
-/// handles spawning the overlay entity.
+/// The framework spawns one overlay quad per registered material and resizes it each
+/// frame to the bounding box of chunks where any of the material's
+/// [`affected_channels`](Self::affected_channels) currently has non-zero data, expanded
+/// by [`padding`](Self::padding) texels. The overlay is hidden entirely when no chunk
+/// has data for any of those channels.
+///
+/// Implementors must:
+/// - Bind the world color texture and the effect data texture array (via `AsBindGroup`).
+/// - Carry a `uv_offset: Vec2` uniform and implement [`set_uv_offset`](Self::set_uv_offset).
+/// - Carry a `quad_world_rect: Vec4` uniform and implement
+///   [`set_quad_world_rect`](Self::set_quad_world_rect). The shader uses this to map the
+///   local quad UV to a world texel via `bevy_falling_sand::effects::quad_uv_to_world_texel`.
+/// - Declare every `(layer, channel)` pair their shader reads via
+///   [`affected_channels`](Self::affected_channels). An empty slice means "render whenever
+///   any registered channel has data anywhere" — appropriate only for fallback materials
+///   that read all channels.
+/// - Override [`padding`](Self::padding) to the maximum texel radius any neighborhood
+///   loop in the shader reaches outside the local channel.
 pub trait ChunkEffectMaterial: Material2d + Sized {
     /// Creates the material from the world color texture and the effect data texture array.
     fn new(chunk_texture: Handle<Image>, effect_data: Handle<Image>) -> Self;
@@ -249,10 +350,24 @@ pub trait ChunkEffectMaterial: Material2d + Sized {
     /// Sets the UV offset for toroidal wrapping when the map origin shifts.
     fn set_uv_offset(&mut self, offset: Vec2);
 
-    /// Number of pixels of padding to include from neighbor chunks around the texture edges.
-    ///
-    /// With world-sized textures, padding is no longer needed since all data is in a
-    /// single texture. This method is retained for trait compatibility but always returns 0.
+    /// Stores the framework-computed quad rectangle uniform consumed by
+    /// `bevy_falling_sand::effects::quad_uv_to_world_texel` to map the local quad UV to
+    /// a texel in the world effect texture array. The value is
+    /// `Vec4(origin_x, origin_y, size_x, size_y)` in world units, with `origin` relative
+    /// to the current map origin.
+    fn set_quad_world_rect(&mut self, rect: Vec4);
+
+    /// `(layer, channel)` pairs that the fragment shader reads from the effect data
+    /// texture array. Drives the active-region bounding box. Empty = "any active channel
+    /// activates this material," used by fallback materials only.
+    #[must_use]
+    fn affected_channels() -> &'static [(usize, usize)] {
+        &[]
+    }
+
+    /// Texel radius the shader's neighborhood loops reach outside any channel-active
+    /// pixel. The active region's bounding box is expanded by this many texels so
+    /// halo / blur effects extend past the underlying particles.
     #[must_use]
     fn padding() -> u32 {
         0
@@ -282,6 +397,9 @@ pub struct DefaultChunkEffectMaterial {
     /// UV offset for toroidal wrapping, computed from the origin shift.
     #[uniform(4)]
     pub uv_offset: Vec2,
+    /// Quad rectangle uniform; consumed by `bevy_falling_sand::effects::quad_uv_to_world_texel`.
+    #[uniform(5)]
+    pub quad_world_rect: Vec4,
 }
 
 impl Material2d for DefaultChunkEffectMaterial {
@@ -300,11 +418,16 @@ impl ChunkEffectMaterial for DefaultChunkEffectMaterial {
             chunk_texture,
             effect_data,
             uv_offset: Vec2::ZERO,
+            quad_world_rect: Vec4::ZERO,
         }
     }
 
     fn set_uv_offset(&mut self, offset: Vec2) {
         self.uv_offset = offset;
+    }
+
+    fn set_quad_world_rect(&mut self, rect: Vec4) {
+        self.quad_world_rect = rect;
     }
 }
 
@@ -357,21 +480,23 @@ impl ChunkEffectApp for App {
 
         self.insert_resource(EffectOverlayZOffset::<M>(z, PhantomData));
         self.add_plugins(Material2dPlugin::<M>::default());
-
+        self.init_resource::<ChunkEffectActiveRegion<M>>();
         self.add_systems(
             Update,
-            (
-                setup_world_effect_overlay::<M>.run_if(
+            setup_world_effect_overlay::<M>
+                .run_if(
                     resource_exists::<WorldColorTexture>
                         .and(resource_exists::<WorldEffectTexture>)
                         .and(not(resource_exists::<WorldEffectEntity<M>>)),
-                ),
-                update_effect_uv_offset::<M>,
-            )
+                )
                 .after(RenderingSystems::ChunkImage),
         );
-
-        self.add_systems(Last, invalidate_world_material::<M>);
+        self.add_systems(
+            PostUpdate,
+            (compute_active_region::<M>, update_effect_overlay::<M>)
+                .chain()
+                .in_set(RenderingSystems::ChunkEffectRegion),
+        );
 
         self
     }
@@ -539,9 +664,9 @@ fn setup_world_textures(
     });
 }
 
-/// Spawns a world-sized effect overlay entity with `MeshMaterial2d<M>`.
-///
-/// Runs once per material type when both world textures exist but `WorldEffectEntity<M>` doesn't.
+/// Spawns the unit-sized effect overlay entity with `MeshMaterial2d<M>`. Each frame the
+/// overlay's transform is resized to the active region by [`update_effect_overlay`], or
+/// hidden when no chunk holds data for any of `M::affected_channels()`.
 #[allow(clippy::needless_pass_by_value)]
 fn setup_world_effect_overlay<M: ChunkEffectMaterial>(
     mut commands: Commands,
@@ -549,28 +674,112 @@ fn setup_world_effect_overlay<M: ChunkEffectMaterial>(
     mut materials: ResMut<Assets<M>>,
     color_tex: Res<WorldColorTexture>,
     effect_tex: Res<WorldEffectTexture>,
-    map: Res<ParticleMap>,
     z_offset: Res<EffectOverlayZOffset<M>>,
 ) {
-    let width = map.width() as f32;
-    let height = map.height() as f32;
-    let origin = map.origin();
-
-    let center_x = origin.x as f32 + width / 2.0;
-    let center_y = origin.y as f32 + height / 2.0;
-
-    let quad = meshes.add(Rectangle::new(width, height));
+    let quad = meshes.add(Rectangle::new(1.0, 1.0));
     let handle = materials.add(M::new(color_tex.0.clone(), effect_tex.0.clone()));
 
     let entity = commands
         .spawn((
             Mesh2d(quad),
             MeshMaterial2d(handle),
-            Transform::from_xyz(center_x, center_y, z_offset.0),
+            Transform::from_xyz(0.0, 0.0, z_offset.0),
+            Visibility::Hidden,
         ))
         .id();
 
     commands.insert_resource(WorldEffectEntity::<M>(entity, PhantomData));
+}
+
+/// Computes the world-space bounding rectangle of all chunks where any of
+/// `M::affected_channels()` currently has non-zero data, padded by `M::padding()` texels.
+/// An empty `affected_channels()` is treated as "any active chunk in
+/// [`ChunkEffectActivity`] contributes" — appropriate for fallback materials that read
+/// every channel.
+#[allow(clippy::needless_pass_by_value)]
+fn compute_active_region<M: ChunkEffectMaterial>(
+    activity: Res<ChunkEffectActivity>,
+    chunk_index: Res<ChunkIndex>,
+    mut region: ResMut<ChunkEffectActiveRegion<M>>,
+) {
+    let channels = M::affected_channels();
+    let slots: Vec<usize> = channels.iter().map(|&(l, c)| l * 4 + c).collect();
+
+    let mut bbox: Option<IRect> = None;
+    for (coord, _) in activity.iter() {
+        if !slots.is_empty() && !activity.any_active(coord, &slots) {
+            continue;
+        }
+        let chunk_rect = chunk_index.chunk_coord_to_chunk_region(coord);
+        bbox = Some(bbox.map_or(chunk_rect, |b| b.union(chunk_rect)));
+    }
+
+    region.0 = bbox.map(|mut b| {
+        let pad = M::padding() as i32;
+        if pad > 0 {
+            b.min -= IVec2::splat(pad);
+            b.max += IVec2::splat(pad);
+        }
+        b
+    });
+}
+
+/// Resizes the overlay quad to the material's active region and pushes the rectangle
+/// (relative to the current map origin) plus the UV offset into the material uniforms.
+/// Hides the entity when no channel is active anywhere.
+#[allow(clippy::needless_pass_by_value)]
+fn update_effect_overlay<M: ChunkEffectMaterial>(
+    map: Res<ParticleMap>,
+    tex_origin: Option<Res<WorldTextureOrigin>>,
+    effect_entity: Option<Res<WorldEffectEntity<M>>>,
+    region: Res<ChunkEffectActiveRegion<M>>,
+    mut materials: ResMut<Assets<M>>,
+    material_query: Query<&MeshMaterial2d<M>>,
+    mut transform_query: Query<(&mut Transform, &mut Visibility)>,
+) {
+    let Some(tex_origin) = tex_origin else { return };
+    let Some(effect_entity) = effect_entity else {
+        return;
+    };
+    let Ok((mut t, mut visibility)) = transform_query.get_mut(effect_entity.0) else {
+        return;
+    };
+
+    let Some(rect) = region.0 else {
+        if *visibility != Visibility::Hidden {
+            *visibility = Visibility::Hidden;
+        }
+        return;
+    };
+
+    let map_origin = map.origin();
+    let size_x = (rect.max.x - rect.min.x + 1) as f32;
+    let size_y = (rect.max.y - rect.min.y + 1) as f32;
+    let cx = size_x.mul_add(0.5, rect.min.x as f32);
+    let cy = size_y.mul_add(0.5, rect.min.y as f32);
+    t.translation.x = cx;
+    t.translation.y = cy;
+    t.scale.x = size_x;
+    t.scale.y = size_y;
+
+    if *visibility == Visibility::Hidden {
+        *visibility = Visibility::Inherited;
+    }
+
+    if let Ok(mat_handle) = material_query.get(effect_entity.0)
+        && let Some(material) = materials.get_mut(&mat_handle.0)
+    {
+        let width = map.width() as f32;
+        let height = map.height() as f32;
+        let shift = map_origin - tex_origin.0;
+        material.set_uv_offset(Vec2::new(shift.x as f32 / width, -shift.y as f32 / height));
+        material.set_quad_world_rect(Vec4::new(
+            (rect.min.x - map_origin.x) as f32,
+            (rect.min.y - map_origin.y) as f32,
+            size_x,
+            size_y,
+        ));
+    }
 }
 
 fn redirty_all_chunks_on_pipeline_ready(
@@ -624,39 +833,6 @@ fn update_world_color_uv_offset(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
-fn update_effect_uv_offset<M: ChunkEffectMaterial>(
-    map: Res<ParticleMap>,
-    tex_origin: Option<Res<WorldTextureOrigin>>,
-    effect_entity: Option<Res<WorldEffectEntity<M>>>,
-    mut materials: ResMut<Assets<M>>,
-    material_query: Query<&MeshMaterial2d<M>>,
-    mut transform_query: Query<&mut Transform>,
-) {
-    let Some(tex_origin) = tex_origin else { return };
-    let Some(effect_entity) = effect_entity else {
-        return;
-    };
-
-    let origin = map.origin();
-    let width = map.width() as f32;
-    let height = map.height() as f32;
-    let center_x = origin.x as f32 + width / 2.0;
-    let center_y = origin.y as f32 + height / 2.0;
-
-    if let Ok(mut t) = transform_query.get_mut(effect_entity.0) {
-        t.translation.x = center_x;
-        t.translation.y = center_y;
-    }
-
-    if let Ok(mat_handle) = material_query.get(effect_entity.0)
-        && let Some(material) = materials.get_mut(&mat_handle.0)
-    {
-        let shift = origin - tex_origin.0;
-        material.set_uv_offset(Vec2::new(shift.x as f32 / width, -shift.y as f32 / height));
-    }
-}
-
 #[allow(
     clippy::too_many_arguments,
     clippy::needless_pass_by_value,
@@ -671,6 +847,7 @@ fn handle_origin_shift(
     mut update_buffer: ResMut<ParticleUpdateBuffer>,
     mut effect_staging: Option<ResMut<WorldEffectShadowBuffer>>,
     mut effect_update_buffer: ResMut<EffectUpdateBuffer>,
+    mut activity: ResMut<ChunkEffectActivity>,
 ) {
     if !loading_state.origin_shifted {
         return;
@@ -691,6 +868,7 @@ fn handle_origin_shift(
 
     let cs = chunk_index.chunk_size() as i32;
     for &(coord, _) in &loading_state.unloaded_this_frame {
+        activity.clear_chunk(coord);
         let min = IVec2::new(coord.x() * cs, coord.y() * cs);
         let max = min + IVec2::splat(cs - 1);
         for y in min.y..=max.y {
@@ -794,6 +972,8 @@ fn update_world_color_texture(
 ///
 /// Iterates dirty positions once, looks up each entity once, evaluates all registered
 /// effect layers, writes to the staging buffer, and packs the update buffer inline.
+/// Updates [`ChunkEffectActivity`] counters as texels transition between zero and
+/// non-zero values so region culling has fresh data.
 fn update_all_effect_layers(world: &mut World) {
     let Some(registry) = world.get_resource::<EffectLayerRegistry>() else {
         return;
@@ -803,10 +983,15 @@ fn update_all_effect_layers(world: &mut World) {
     }
     let layers = registry.layers.clone();
     let active_texture_layers = registry.active_texture_layers.clone();
+    let texture_layer_count = registry.texture_layer_count;
 
     let Some(&WorldTextureOrigin(origin)) = world.get_resource::<WorldTextureOrigin>() else {
         return;
     };
+
+    world
+        .resource_mut::<ChunkEffectActivity>()
+        .ensure_slots(texture_layer_count * 4);
 
     let mut cache = world.resource_mut::<EffectSystemCache>();
     let mut dirty_entries = std::mem::take(&mut cache.dirty_entries);
@@ -816,76 +1001,42 @@ fn update_all_effect_layers(world: &mut World) {
     let state = cached_state.get_or_insert_with(|| SystemState::new(world));
 
     {
-        let (map, staging, dirty_chunks) = state.get(world);
-
-        let world_w_i32 = staging.width as i32;
-        let world_h = staging.height as i32;
-
-        for (region, dirty_state) in dirty_chunks.iter() {
-            let Some(dirty_rect) = dirty_state.current else {
-                continue;
-            };
-            let rect = region.region();
-
-            if let Some(ref positions) = dirty_state.current_positions {
-                for &pos in positions {
-                    if !rect.contains(pos) {
-                        continue;
-                    }
-                    let (tx, ty) = world_to_texel(pos, origin, world_w_i32, world_h);
-                    let entity = map.get_copied(pos).ok().flatten();
-                    dirty_entries.push((tx, ty, entity));
-                }
-            } else {
-                let min_x = dirty_rect.min.x.max(rect.min.x);
-                let max_x = dirty_rect.max.x.min(rect.max.x);
-                let min_y = dirty_rect.min.y.max(rect.min.y);
-                let max_y = dirty_rect.max.y.min(rect.max.y);
-
-                for y in min_y..=max_y {
-                    for x in min_x..=max_x {
-                        let pos = IVec2::new(x, y);
-                        let (tx, ty) = world_to_texel(pos, origin, world_w_i32, world_h);
-                        let entity = map.get_copied(pos).ok().flatten();
-                        dirty_entries.push((tx, ty, entity));
-                    }
-                }
-            }
-        }
+        let (map, chunk_index, staging, dirty_chunks) = state.get(world);
+        collect_dirty_entries(
+            chunk_index.chunk_size() as i32,
+            staging.width as i32,
+            staging.height as i32,
+            origin,
+            &map,
+            dirty_chunks.iter(),
+            &mut dirty_entries,
+        );
     }
 
     world.resource_scope(|world, mut staging: Mut<WorldEffectShadowBuffer>| {
         world.resource_scope(|world, mut update_buffer: Mut<EffectUpdateBuffer>| {
-            update_buffer.updates.clear();
-            let world_w = staging.width as usize;
-            let layer_stride = staging.height as usize * world_w;
+            world.resource_scope(|world, mut activity: Mut<ChunkEffectActivity>| {
+                update_buffer.updates.clear();
+                let world_w = staging.width as usize;
+                let layer_stride = staging.height as usize * world_w;
 
-            for &(tx, ty, entity_opt) in &dirty_entries {
-                for layer_def in &layers {
-                    let val = entity_opt.map_or(0, |e| {
-                        world.get_entity(e).ok().map_or(0u8, |er| {
-                            if er.contains_id(layer_def.component_id) {
-                                255
-                            } else {
-                                0
-                            }
-                        })
-                    });
-                    let idx = (layer_def.layer * layer_stride + ty * world_w + tx) * 4
-                        + layer_def.channel;
-                    staging.data[idx] = val;
+                for &(tx, ty, entity_opt, chunk_coord) in &dirty_entries {
+                    apply_effect_entry(
+                        tx,
+                        ty,
+                        entity_opt,
+                        chunk_coord,
+                        &layers,
+                        &active_texture_layers,
+                        layer_stride,
+                        world_w,
+                        world,
+                        &mut staging,
+                        &mut activity,
+                        &mut update_buffer,
+                    );
                 }
-
-                for &layer_idx in &active_texture_layers {
-                    let base = (layer_idx * layer_stride + ty * world_w + tx) * 4;
-                    let packed_pos = (tx as u32) | ((ty as u32) << 14) | ((layer_idx as u32) << 28);
-                    let packed_rgba = u32::from(staging.data[base])
-                        | (u32::from(staging.data[base + 1]) << 8)
-                        | (u32::from(staging.data[base + 2]) << 16)
-                        | (u32::from(staging.data[base + 3]) << 24);
-                    update_buffer.updates.push([packed_pos, packed_rgba]);
-                }
-            }
+            });
         });
     });
 
@@ -894,33 +1045,100 @@ fn update_all_effect_layers(world: &mut World) {
     cache.state = cached_state;
 }
 
-/// Marks a world effect material as changed when any chunk is dirty,
-/// forcing a bind group rebuild.
-fn invalidate_world_material<M: ChunkEffectMaterial>(
-    mut materials: ResMut<Assets<M>>,
-    effect_entity: Option<Res<WorldEffectEntity<M>>>,
-    dirty_chunks: Query<&ChunkDirtyState>,
-    material_query: Query<&MeshMaterial2d<M>>,
+fn collect_dirty_entries<'a>(
+    chunk_size: i32,
+    world_w: i32,
+    world_h: i32,
+    origin: IVec2,
+    map: &ParticleMap,
+    dirty_chunks: impl Iterator<Item = (&'a ChunkRegion, &'a ChunkDirtyState)>,
+    out: &mut Vec<(usize, usize, Option<Entity>, ChunkCoord)>,
 ) {
-    let Some(effect_entity) = effect_entity else {
-        return;
-    };
+    for (region, dirty_state) in dirty_chunks {
+        let Some(dirty_rect) = dirty_state.current else {
+            continue;
+        };
+        let rect = region.region();
+        let chunk_coord = ChunkCoord::new(
+            rect.min.x.div_euclid(chunk_size),
+            rect.min.y.div_euclid(chunk_size),
+        );
 
-    let any_dirty = dirty_chunks
-        .iter()
-        .any(crate::core::ChunkDirtyState::is_dirty);
-    if !any_dirty {
-        return;
-    }
+        if let Some(ref positions) = dirty_state.current_positions {
+            for &pos in positions {
+                if !rect.contains(pos) {
+                    continue;
+                }
+                let (tx, ty) = world_to_texel(pos, origin, world_w, world_h);
+                let entity = map.get_copied(pos).ok().flatten();
+                out.push((tx, ty, entity, chunk_coord));
+            }
+        } else {
+            let min_x = dirty_rect.min.x.max(rect.min.x);
+            let max_x = dirty_rect.max.x.min(rect.max.x);
+            let min_y = dirty_rect.min.y.max(rect.min.y);
+            let max_y = dirty_rect.max.y.min(rect.max.y);
 
-    if let Ok(mat) = material_query.get(effect_entity.0) {
-        let _ = materials.get_mut(&mat.0);
+            for y in min_y..=max_y {
+                for x in min_x..=max_x {
+                    let pos = IVec2::new(x, y);
+                    let (tx, ty) = world_to_texel(pos, origin, world_w, world_h);
+                    let entity = map.get_copied(pos).ok().flatten();
+                    out.push((tx, ty, entity, chunk_coord));
+                }
+            }
+        }
     }
 }
 
-// ---------------------------------------------------------------------------
-// Persistence helpers
-// ---------------------------------------------------------------------------
+#[allow(clippy::too_many_arguments)]
+fn apply_effect_entry(
+    tx: usize,
+    ty: usize,
+    entity_opt: Option<Entity>,
+    chunk_coord: ChunkCoord,
+    layers: &[RegisteredEffectLayer],
+    active_texture_layers: &[usize],
+    layer_stride: usize,
+    world_w: usize,
+    world: &World,
+    staging: &mut WorldEffectShadowBuffer,
+    activity: &mut ChunkEffectActivity,
+    update_buffer: &mut EffectUpdateBuffer,
+) {
+    for layer_def in layers {
+        let val = entity_opt.map_or(0, |e| {
+            world.get_entity(e).ok().map_or(0u8, |er| {
+                if er.contains_id(layer_def.component_id) {
+                    255
+                } else {
+                    0
+                }
+            })
+        });
+        let idx = (layer_def.layer * layer_stride + ty * world_w + tx) * 4 + layer_def.channel;
+        let old = staging.data[idx];
+        if old != val {
+            let slot = layer_def.layer * 4 + layer_def.channel;
+            if old == 0 && val > 0 {
+                activity.inc(chunk_coord, slot);
+            } else if old > 0 && val == 0 {
+                activity.dec(chunk_coord, slot);
+            }
+            staging.data[idx] = val;
+        }
+    }
+
+    for &layer_idx in active_texture_layers {
+        let base = (layer_idx * layer_stride + ty * world_w + tx) * 4;
+        let packed_pos = (tx as u32) | ((ty as u32) << 14) | ((layer_idx as u32) << 28);
+        let packed_rgba = u32::from(staging.data[base])
+            | (u32::from(staging.data[base + 1]) << 8)
+            | (u32::from(staging.data[base + 2]) << 16)
+            | (u32::from(staging.data[base + 3]) << 24);
+        update_buffer.updates.push([packed_pos, packed_rgba]);
+    }
+}
 
 /// Builds a chunk-sized RGBA8 image by querying particle colors from the ECS.
 ///

--- a/src/render/schedule.rs
+++ b/src/render/schedule.rs
@@ -7,6 +7,9 @@
 //!
 //! **`PostUpdate`:**
 //! - [`RenderingSystems::ChunkEffectLayerUpdate`] — chunk effect layer updates
+//! - [`RenderingSystems::ChunkEffectRegion`] — per-material active-region computation
+//!   and overlay sizing for region-culled materials. Runs after
+//!   [`RenderingSystems::ChunkEffectLayerUpdate`].
 
 use bevy::prelude::*;
 
@@ -19,9 +22,13 @@ impl Plugin for SchedulePlugin {
         app.configure_sets(Update, RenderingSystems::ChunkImage)
             .configure_sets(
                 PostUpdate,
-                RenderingSystems::ChunkEffectLayerUpdate
-                    .after(ParticleSystems::Simulation)
-                    .after(ChunkSystems::Cleanup),
+                (
+                    RenderingSystems::ChunkEffectLayerUpdate
+                        .after(ParticleSystems::Simulation)
+                        .after(ChunkSystems::Cleanup),
+                    RenderingSystems::ChunkEffectRegion
+                        .after(RenderingSystems::ChunkEffectLayerUpdate),
+                ),
             );
     }
 }
@@ -37,4 +44,7 @@ pub enum RenderingSystems {
     /// [`ParticleSystems::Simulation`] and
     /// [`ChunkSystems::Cleanup`].
     ChunkEffectLayerUpdate,
+    /// Runs in `PostUpdate` after [`RenderingSystems::ChunkEffectLayerUpdate`]. Hosts the
+    /// per-material `compute_active_region` and overlay sizing systems.
+    ChunkEffectRegion,
 }


### PR DESCRIPTION
The previous rendering paradigm ran extremely poorly on integrated GPUs. Regardless of whether a particle with an effect was present in the world, its shader was evaluted/exectued for all occupied particle positions. For poorly written shaders (such as the ones I wrote for this project), pixels are needlessly performing complex operations like expanding region searches

These changes update those shaders to only execute on pixels that are actually occupied by relevant particles. We also introduce culling at multiple stages:

- compute_active_region<M> now uses Option<IRect> in the event no particles with effects are present in the actively simulated world
- Add a bounding box (bbox) in compute_active_region, which is a computed union rect of all regions with effects for the relevant material within a single chunk. Shaders can utilize this to ensure they are only computing pixels within regions that need to be updated.