### PR TITLE
bug: fix z layer ordering for particle scenes

### DIFF
--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -314,7 +314,7 @@ fn handle_spawn_scene(
         let root = signal.root.unwrap_or_else(|| commands.spawn_empty().id());
         commands.entity(root).try_insert(ParticleSceneRoot);
 
-        for (layer_index, layer) in scene.layers.iter().rev().enumerate() {
+        for (layer_index, layer) in scene.layers.iter().enumerate().rev() {
             match layer {
                 SceneLayer::Particles { image, colors } => {
                     if !spawn_particles_layer(


### PR DESCRIPTION
Call <iter()>.enumerate() before <iter()>.rev() so we preserve the original z ordering