### PR TITLE
'has_effect_in_radius' was causing a bug with particle shaders

### DIFF
--- a/assets/shaders/burning_effect.wgsl
+++ b/assets/shaders/burning_effect.wgsl
@@ -1,6 +1,5 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
-#import bevy_falling_sand::effects::has_effect_in_radius
 #import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct BurningSettings {
@@ -23,10 +22,6 @@ fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     let has_burning = effects.a > 0.5;
     let halo_radius = 6;
-
-    if !has_burning && !has_effect_in_radius(effect_data_texture, 0, 3, texel, tex_size, halo_radius, 2) {
-        discard;
-    }
 
     let color = textureLoad(chunk_texture, texel, 0);
 

--- a/assets/shaders/glow_effect.wgsl
+++ b/assets/shaders/glow_effect.wgsl
@@ -1,6 +1,5 @@
 #import bevy_sprite::mesh2d_vertex_output::VertexOutput
 #import bevy_sprite::mesh2d_view_bindings::globals
-#import bevy_falling_sand::effects::has_effect_in_radius
 #import bevy_falling_sand::effects::quad_uv_to_world_texel
 
 struct GlowSettings {
@@ -29,10 +28,6 @@ fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
     let effects = textureLoad(effect_data_texture, texel, 0, 0);
     let has_glow = effects.b > 0.5;
     let radius_i = i32(settings.radius);
-
-    if !has_glow && !has_effect_in_radius(effect_data_texture, 0, 2, texel, tex_size, radius_i, 4) {
-        discard;
-    }
 
     let time = globals.time;
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -215,12 +215,10 @@
 //!
 //! The shader receives the color texture, the effect data texture array, the UV offset,
 //! and the `quad_world_rect` uniform that maps the local quad UV to a world texel.
-//! Import the `bevy_falling_sand::effects` helper module to map UVs to texels and to
-//! cheaply scan a neighborhood for active effect channels before any expensive work.
+//! Import the `bevy_falling_sand::effects` helper module to map UVs to texels.
 //!
 //! ```wgsl
 //! #import bevy_falling_sand::effects::quad_uv_to_world_texel
-//! #import bevy_falling_sand::effects::has_effect_in_radius
 //!
 //! @group(2) @binding(0) var chunk_texture: texture_2d<f32>;
 //! @group(2) @binding(1) var chunk_sampler: sampler;
@@ -233,12 +231,6 @@
 //! fn fragment(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 //!     let tex_size = vec2<i32>(textureDimensions(chunk_texture, 0));
 //!     let texel = quad_uv_to_world_texel(uv, quad_world_rect, tex_size, uv_offset);
-//!
-//!     // Cheap presence test before any radius loop. Discard pixels that cannot
-//!     // contribute output. `stride > 1` makes the scan sub-linear in radius.
-//!     if !has_effect_in_radius(effect_data, 0, 2, texel, tex_size, 12, 4) {
-//!         discard;
-//!     }
 //!
 //!     let color = textureLoad(chunk_texture, texel, 0);
 //!     let layer0 = textureLoad(effect_data, texel, 0, 0);

--- a/src/render/pipeline/shaders/effects.wgsl
+++ b/src/render/pipeline/shaders/effects.wgsl
@@ -1,42 +1,5 @@
 #define_import_path bevy_falling_sand::effects
 
-fn effect_channel(
-    effect_data: texture_2d_array<f32>,
-    layer: i32,
-    channel: i32,
-    texel: vec2<i32>,
-) -> f32 {
-    let v = textureLoad(effect_data, texel, layer, 0);
-    if channel == 0 { return v.r; }
-    if channel == 1 { return v.g; }
-    if channel == 2 { return v.b; }
-    return v.a;
-}
-
-fn has_effect_in_radius(
-    effect_data: texture_2d_array<f32>,
-    layer: i32,
-    channel: i32,
-    texel: vec2<i32>,
-    tex_size: vec2<i32>,
-    radius: i32,
-    stride: i32,
-) -> bool {
-    let s = max(stride, 1);
-    for (var dy = -radius; dy <= radius; dy = dy + s) {
-        for (var dx = -radius; dx <= radius; dx = dx + s) {
-            let n = texel + vec2<i32>(dx, dy);
-            if n.x < 0 || n.y < 0 || n.x >= tex_size.x || n.y >= tex_size.y {
-                continue;
-            }
-            if effect_channel(effect_data, layer, channel, n) > 0.5 {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 // Maps a fragment's local quad UV to a texel in the world effect / color texture.
 //
 // `quad_world_rect` is `(min_x, min_y, size_x, size_y)` in world coordinates, relative


### PR DESCRIPTION
'has_effect_in_radius' was introduced to allow a short circuit path for particles that didn't need to have their shader effect updated on the screen. Something about this is causing a graphical artifact with glowing/burning particles (or any shader that samples its surrounding region for effects). Every other pixel in the surrounding region was being affected, resulting in an alternating graphical effect. I wasn't able to figure out exactly what was causing this, but the recent updates we made for culling shaders provided a big enough win in the rendering space. We will remove this for now and revisit at a later date.