### PR TITLE
feature: optimize/improve reactions

### DIFF
--- a/src/reactions/contact.rs
+++ b/src/reactions/contact.rs
@@ -238,14 +238,14 @@ fn resolve_changed_contact_reactions(
 fn handle_contact_reactions(
     map: Res<ParticleMap>,
     chunk_index: Res<ChunkIndex>,
-    chunk_query: Query<&ChunkDirtyState>,
+    mut chunk_query: Query<&mut ChunkDirtyState>,
     particle_query: Query<&AttachedToParticleType, With<Particle>>,
     rules_query: Query<&ResolvedContactReaction, With<ParticleType>>,
     mut rng: ResMut<GlobalRng>,
     mut msgw_spawn: MessageWriter<SpawnParticleSignal>,
 ) {
     for (_coord, chunk_entity) in chunk_index.iter() {
-        let Ok(dirty_state) = chunk_query.get(chunk_entity) else {
+        let Ok(mut dirty_state) = chunk_query.get_mut(chunk_entity) else {
             continue;
         };
 
@@ -291,23 +291,26 @@ fn handle_contact_reactions(
                         if dist_sq > rule.radius * rule.radius {
                             continue;
                         }
-                        if neighbor_attached.0 == rule.target_type && rng.chance(rule.chance) {
-                            match rule.consumes {
-                                Consumes::Source => {
-                                    msgw_spawn.write(SpawnParticleSignal::overwrite_existing(
-                                        rule.becomes.clone(),
-                                        pos,
-                                    ));
+                        if neighbor_attached.0 == rule.target_type {
+                            if rng.chance(rule.chance) {
+                                match rule.consumes {
+                                    Consumes::Source => {
+                                        msgw_spawn.write(SpawnParticleSignal::overwrite_existing(
+                                            rule.becomes.clone(),
+                                            pos,
+                                        ));
+                                    }
+                                    Consumes::Target => {
+                                        msgw_spawn.write(SpawnParticleSignal::overwrite_existing(
+                                            rule.becomes.clone(),
+                                            neighbor_pos,
+                                        ));
+                                    }
                                 }
-                                Consumes::Target => {
-                                    msgw_spawn.write(SpawnParticleSignal::overwrite_existing(
-                                        rule.becomes.clone(),
-                                        neighbor_pos,
-                                    ));
-                                }
+                                reacted = true;
+                                break;
                             }
-                            reacted = true;
-                            break;
+                            dirty_state.mark_dirty(pos);
                         }
                     }
                 }

--- a/src/reactions/corrosion.rs
+++ b/src/reactions/corrosion.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{GridPosition, ParticleMap, ParticleSyncExt, ParticleSystems};
+use crate::{
+    ChunkDirtyState, ChunkIndex, GridPosition, ParticleMap, ParticleSyncExt, ParticleSystems,
+};
 
 pub(super) struct CorrosionPlugin;
 
@@ -83,12 +85,58 @@ pub struct Corrodible;
 fn handle_corrosion(
     mut commands: Commands,
     map: Res<ParticleMap>,
+    chunk_index: Res<ChunkIndex>,
+    mut chunk_query: Query<&mut ChunkDirtyState>,
     time: Res<Time>,
     mut corrosive: Query<(&mut Corrosive, &GridPosition)>,
     corrodible: Query<&Corrodible>,
     mut rng: ResMut<bevy_turborand::prelude::GlobalRng>,
 ) {
     use bevy_turborand::DelegatedRng;
+
+    for (_coord, chunk_entity) in chunk_index.iter() {
+        let Ok(mut dirty_state) = chunk_query.get_mut(chunk_entity) else {
+            continue;
+        };
+
+        let Some(dirty_rect) = dirty_state.current else {
+            continue;
+        };
+
+        for y in dirty_rect.min.y..=dirty_rect.max.y {
+            for x in dirty_rect.min.x..=dirty_rect.max.x {
+                let pos = IVec2::new(x, y);
+
+                let Ok(Some(entity)) = map.get_copied(pos) else {
+                    continue;
+                };
+
+                let Ok((corrosive, _)) = corrosive.get_mut(entity) else {
+                    continue;
+                };
+
+                for (neighbor_pos, neighbor_entity) in map.within_radius(pos, 1.0) {
+                    if neighbor_pos == pos {
+                        continue;
+                    }
+
+                    let Ok(_) = corrodible.get(neighbor_entity) else {
+                        continue;
+                    };
+
+                    if !rng.chance(corrosive.chance) {
+                        dirty_state.mark_dirty(pos);
+                        continue;
+                    }
+
+                    if corrodible.get(neighbor_entity).is_ok() {
+                        commands.entity(neighbor_entity).despawn();
+                    }
+                }
+            }
+        }
+    }
+
     corrosive.iter_mut().for_each(|(mut corrosive, pos)| {
         if let Ok(e) = map.get_copied(pos.0)
             && e.is_some()

--- a/src/reactions/fire.rs
+++ b/src/reactions/fire.rs
@@ -454,14 +454,14 @@ fn handle_fire(
     mut commands: Commands,
     map: Res<ParticleMap>,
     chunk_index: Res<ChunkIndex>,
-    chunk_query: Query<&ChunkDirtyState>,
+    mut chunk_query: Query<&mut ChunkDirtyState>,
     fire_query: Query<&Fire>,
     burns_query: Query<&Flammable, (With<Particle>, Without<Burning>)>,
     mut rng: ResMut<bevy_turborand::prelude::GlobalRng>,
 ) {
     use bevy_turborand::DelegatedRng;
     for (_coord, chunk_entity) in chunk_index.iter() {
-        let Ok(dirty_state) = chunk_query.get(chunk_entity) else {
+        let Ok(mut dirty_state) = chunk_query.get_mut(chunk_entity) else {
             continue;
         };
 
@@ -491,6 +491,7 @@ fn handle_fire(
                     };
 
                     if !rng.chance(burns.chance_to_ignite) {
+                        dirty_state.mark_dirty(pos);
                         continue;
                     }
 


### PR DESCRIPTION
Previously, reactions worked slightly differently between `contact`, `fire,` and `corrosion`, and some of these were prone to not reacting with neighbors when they should be (specifically because they have no dirty rects).

The new approach is this: For all dirty particles with a reaction type, query their neighbors. If any of their neighbors is a match for reacting, and the chance fails, mark the current particle's position as dirty and continue. This basically forces the incident particle to continuously check for valid neighbors and perform its reaction until no valid neighbors remain, at which point the particle will stop being marked as dirty.