### PR TITLE
Make Particle a zero-sized marker component

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -103,11 +103,11 @@ fn setup(mut commands: Commands) {
     ));
 
     commands.insert_resource(ParticleSpawnList::new(vec![
-        Particle::new("Dirt Wall"),
-        Particle::new("Sand"),
-        Particle::new("Water"),
+        "Dirt Wall".into(),
+        "Sand".into(),
+        "Water".into(),
     ]));
-    commands.insert_resource(SelectedBrushParticle(Particle::new("Dirt Wall")));
+    commands.insert_resource(SelectedBrushParticle("Dirt Wall".into()));
 
     let instructions_text = "Left mouse: Spawn/despawn particles\n\
         Right mouse: Cycle particle type\n\

--- a/examples/fire.rs
+++ b/examples/fire.rs
@@ -230,10 +230,10 @@ fn setup(
     ));
 
     commands.insert_resource(ParticleSpawnList::new(vec![
-        Particle::new("FIRE"),
-        Particle::new("Flammable Gas"),
+        "FIRE".into(),
+        "Flammable Gas".into(),
     ]));
-    commands.insert_resource(SelectedBrushParticle(Particle::new("FIRE")));
+    commands.insert_resource(SelectedBrushParticle("FIRE".into()));
 
     let instructions_text = "Left mouse: Spawn/despawn particles\n\
         Right mouse: Cycle particle type\n\
@@ -281,7 +281,7 @@ fn setup(
     });
 }
 
-fn spawn_flammable_gas_particles(mut commands: Commands) {
+fn spawn_flammable_gas_particles(mut spawn_writer: MessageWriter<SpawnParticleSignal>) {
     let center_x = (START_X + END_X) / 2;
     let center_y = (START_Y + END_Y) / 2;
 
@@ -290,13 +290,8 @@ fn spawn_flammable_gas_particles(mut commands: Commands) {
     for dx in -radius..=radius {
         for dy in -radius..=radius {
             if dx * dx + dy * dy <= radius * radius {
-                let spawn_x = center_x as f32 + dx as f32;
-                let spawn_y = center_y as f32 + dy as f32;
-
-                commands.spawn((
-                    Particle::new("Flammable Gas"),
-                    Transform::from_xyz(spawn_x, spawn_y, 0.0),
-                ));
+                let position = IVec2::new(center_x + dx, center_y + dy);
+                spawn_writer.write(SpawnParticleSignal::new("Flammable Gas", position));
             }
         }
     }
@@ -406,7 +401,7 @@ fn render_fire_settings_gui(
             if ui.checkbox(&mut smoke_enabled, "Smoke").changed() {
                 if smoke_enabled {
                     burns.reaction = Some(BurnProduct {
-                        produces: Particle::new("Smoke"),
+                        produces: "Smoke".into(),
                         chance_to_produce: 0.5,
                     });
                 } else {
@@ -432,7 +427,7 @@ fn render_fire_settings_gui(
                     .drag_stopped()
                 {
                     burns.reaction = Some(BurnProduct {
-                        produces: Particle::new("Smoke"),
+                        produces: "Smoke".into(),
                         chance_to_produce,
                     });
                     fire_updated = true;

--- a/examples/movement.rs
+++ b/examples/movement.rs
@@ -170,17 +170,17 @@ fn setup(
 
     // Setup particle spawn list for brush system
     let particles = vec![
-        Particle::new("Moore Neighborhood Particle (no momentum)"),
-        Particle::new("Moore Neighborhood Particle (with momentum)"),
-        Particle::new("Neumann Neighborhood Particle (no momentum)"),
-        Particle::new("Neumann Neighborhood Particle (with momentum)"),
-        Particle::new("Downward diagonal (no momentum)"),
-        Particle::new("Downward diagonal (with momentum)"),
+        "Moore Neighborhood Particle (no momentum)".into(),
+        "Moore Neighborhood Particle (with momentum)".into(),
+        "Neumann Neighborhood Particle (no momentum)".into(),
+        "Neumann Neighborhood Particle (with momentum)".into(),
+        "Downward diagonal (no momentum)".into(),
+        "Downward diagonal (with momentum)".into(),
     ];
     commands.insert_resource(ParticleSpawnList::new(particles));
-    commands.insert_resource(SelectedBrushParticle(Particle::new(
-        "Moore Neighborhood Particle (no momentum)",
-    )));
+    commands.insert_resource(SelectedBrushParticle(
+        "Moore Neighborhood Particle (no momentum)".into(),
+    ));
 
     let instructions_text = "Left mouse: Spawn/despawn particles\n\
         Right mouse: Cycle particle type\n\

--- a/examples/mutation.rs
+++ b/examples/mutation.rs
@@ -190,24 +190,29 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn spawn_particles(mut commands: Commands, time: Res<Time>, mut rng: ResMut<GlobalRng>) {
+fn spawn_particles(
+    mut spawn_writer: MessageWriter<SpawnParticleSignal>,
+    time: Res<Time>,
+    mut rng: ResMut<GlobalRng>,
+) {
     if time.elapsed_secs() < 0.5 {
         let x_range = ((END_X - START_X) as f32 * 0.5) as i32;
         let y_range = ((END_Y - START_Y) as f32 * 0.5) as i32;
 
         for x in START_X + 50..START_X + 50 + x_range {
             for y in START_Y + 50..START_Y + 50 + y_range {
+                let position = IVec2::new(x, -y);
                 if rng.chance(0.5) {
-                    commands.spawn((
-                        Particle::new("Water"),
-                        Transform::from_xyz(x as f32, -(y as f32), 0.0),
-                        MutationParticleOne,
+                    spawn_writer.write(SpawnParticleSignal::new("Water", position).with_on_spawn(
+                        |cmd| {
+                            cmd.insert(MutationParticleOne);
+                        },
                     ));
                 } else if rng.chance(0.5) {
-                    commands.spawn((
-                        Particle::new("Sand"),
-                        Transform::from_xyz(x as f32, -(y as f32), 0.0),
-                        MutationParticleTwo,
+                    spawn_writer.write(SpawnParticleSignal::new("Sand", position).with_on_spawn(
+                        |cmd| {
+                            cmd.insert(MutationParticleTwo);
+                        },
                     ));
                 }
             }
@@ -216,7 +221,8 @@ fn spawn_particles(mut commands: Commands, time: Res<Time>, mut rng: ResMut<Glob
 }
 
 fn mutate_particle_type_one(
-    mut mutate_particle_query: Query<&mut Particle, With<MutationParticleOne>>,
+    mut mutate_particle_query: Query<&mut AttachedToParticleType, With<MutationParticleOne>>,
+    registry: Res<ParticleTypeRegistry>,
     state: Res<State<ParticleTypeOneMutationState>>,
     mut next_state: ResMut<NextState<ParticleTypeOneMutationState>>,
     mut particle_type_text_query: Query<&mut Text, With<ParticleTypeOneText>>,
@@ -227,18 +233,22 @@ fn mutate_particle_type_one(
         ParticleTypeOneMutationState::Sand => ParticleTypeOneMutationState::Water,
         ParticleTypeOneMutationState::Water => ParticleTypeOneMutationState::Smoke,
     };
-    mutate_particle_query.iter_mut().for_each(|mut particle| {
-        particle.name = format!("{new_state}").into();
-    });
+    let new_name = format!("{new_state}");
+    if let Some(&new_parent) = registry.get(&new_name) {
+        mutate_particle_query.iter_mut().for_each(|mut attached| {
+            attached.0 = new_parent;
+        });
+    }
     next_state.set(new_state.clone());
-    let new_text = format!("Particle Type: {}", new_state.clone());
+    let new_text = format!("Particle Type: {new_name}");
     for mut particle_type_text in particle_type_text_query.iter_mut() {
         (**particle_type_text).clone_from(&new_text);
     }
 }
 
 fn mutate_particle_type_two(
-    mut mutate_particle_query: Query<&mut Particle, With<MutationParticleTwo>>,
+    mut mutate_particle_query: Query<&mut AttachedToParticleType, With<MutationParticleTwo>>,
+    registry: Res<ParticleTypeRegistry>,
     state: Res<State<ParticleTypeTwoMutationState>>,
     mut next_state: ResMut<NextState<ParticleTypeTwoMutationState>>,
     mut particle_type_text_query: Query<&mut Text, With<ParticleTypeTwoText>>,
@@ -249,11 +259,14 @@ fn mutate_particle_type_two(
         ParticleTypeTwoMutationState::Sand => ParticleTypeTwoMutationState::Water,
         ParticleTypeTwoMutationState::Water => ParticleTypeTwoMutationState::Smoke,
     };
-    mutate_particle_query.iter_mut().for_each(|mut particle| {
-        particle.name = format!("{new_state}").into();
-    });
+    let new_name = format!("{new_state}");
+    if let Some(&new_parent) = registry.get(&new_name) {
+        mutate_particle_query.iter_mut().for_each(|mut attached| {
+            attached.0 = new_parent;
+        });
+    }
     next_state.set(new_state.clone());
-    let new_text = format!("Particle Type: {}", new_state.clone());
+    let new_text = format!("Particle Type: {new_name}");
     for mut particle_type_text in particle_type_text_query.iter_mut() {
         (**particle_type_text).clone_from(&new_text);
     }

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -223,7 +223,7 @@ fn spawn_noise(spawn_writer: &mut MessageWriter<SpawnParticleSignal>, rng: &mut 
             spawn_writer.write(
                 SpawnParticleSignal::overwrite_existing("Dirt Wall", position).with_on_spawn(
                     move |cmd| {
-                        cmd.insert(force_color.clone());
+                        cmd.insert(force_color);
                     },
                 ),
             );

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -60,7 +60,11 @@ fn main() {
 #[derive(Default, Resource)]
 struct SpawnParticles;
 
-fn setup(mut commands: Commands, mut rng: ResMut<GlobalRng>) {
+fn setup(
+    mut commands: Commands,
+    mut rng: ResMut<GlobalRng>,
+    mut spawn_writer: MessageWriter<SpawnParticleSignal>,
+) {
     commands.remove_resource::<DebugParticleMap>();
     commands.remove_resource::<DebugDirtyRects>();
     commands.spawn((
@@ -105,11 +109,11 @@ fn setup(mut commands: Commands, mut rng: ResMut<GlobalRng>) {
     ));
 
     commands.insert_resource(ParticleSpawnList::new(vec![
-        Particle::new("Dirt Wall"),
-        Particle::new("Sand"),
-        Particle::new("Water"),
+        "Dirt Wall".into(),
+        "Sand".into(),
+        "Water".into(),
     ]));
-    commands.insert_resource(SelectedBrushParticle(Particle::new("Dirt Wall")));
+    commands.insert_resource(SelectedBrushParticle("Dirt Wall".into()));
 
     let instructions_text = "Left mouse: Spawn/despawn particles\n\
         Right mouse: Cycle particle type\n\
@@ -155,19 +159,19 @@ fn setup(mut commands: Commands, mut rng: ResMut<GlobalRng>) {
         ));
     });
 
-    spawn_noise(&mut commands, &mut rng);
+    spawn_noise(&mut spawn_writer, &mut rng);
 }
 
 fn reset_noise(
-    mut commands: Commands,
     mut rng: ResMut<GlobalRng>,
     mut despawn_writer: MessageWriter<DespawnAllParticlesSignal>,
+    mut spawn_writer: MessageWriter<SpawnParticleSignal>,
 ) {
     despawn_writer.write(DespawnAllParticlesSignal);
-    spawn_noise(&mut commands, &mut rng);
+    spawn_noise(&mut spawn_writer, &mut rng);
 }
 
-fn spawn_noise(commands: &mut Commands, rng: &mut GlobalRng) {
+fn spawn_noise(spawn_writer: &mut MessageWriter<SpawnParticleSignal>, rng: &mut GlobalRng) {
     let seed = rng.u32(0..u32::MAX);
 
     let basic_multi = Fbm::<PerlinSurflet>::new(seed);
@@ -211,19 +215,18 @@ fn spawn_noise(commands: &mut Commands, rng: &mut GlobalRng) {
             if val < -0.5 {
                 continue;
             }
-            commands.spawn((
-                Transform::from_xyz(
-                    (x as i32 - grid_width as i32 / 2) as f32,
-                    (y as i32 - grid_height as i32 / 2) as f32,
-                    0.,
+            let position = IVec2::new(
+                x as i32 - grid_width as i32 / 2,
+                y as i32 - grid_height as i32 / 2,
+            );
+            let force_color = ForceColor(Color::Srgba(color));
+            spawn_writer.write(
+                SpawnParticleSignal::overwrite_existing("Dirt Wall", position).with_on_spawn(
+                    move |cmd| {
+                        cmd.insert(force_color.clone());
+                    },
                 ),
-                Sprite {
-                    color: Color::Srgba(color),
-                    ..Default::default()
-                },
-                Particle::new("Dirt Wall"),
-                ForceColor(Color::Srgba(color)),
-            ));
+            );
         }
     }
 }

--- a/examples/rigid_bodies.rs
+++ b/examples/rigid_bodies.rs
@@ -117,11 +117,11 @@ fn setup(mut commands: Commands) {
     }
 
     commands.insert_resource(ParticleSpawnList::new(vec![
-        Particle::new("Dirt Wall"),
-        Particle::new("Sand"),
-        Particle::new("Water"),
+        "Dirt Wall".into(),
+        "Sand".into(),
+        "Water".into(),
     ]));
-    commands.insert_resource(SelectedBrushParticle(Particle::new("Dirt Wall")));
+    commands.insert_resource(SelectedBrushParticle("Dirt Wall".into()));
 
     let instructions_text = "Left mouse: Spawn/despawn particles\n\
         Right mouse: Cycle particle type\n\

--- a/examples/utils/brush.rs
+++ b/examples/utils/brush.rs
@@ -1,6 +1,7 @@
 use bevy::{input::mouse::MouseWheel, prelude::*};
 use bevy_falling_sand::prelude::{
-    DespawnParticleSignal, Particle, ParticleMap, ParticleSystems, SpawnParticleSignal,
+    AttachedToParticleType, DespawnParticleSignal, Particle, ParticleMap, ParticleSystems,
+    ParticleType, SpawnParticleSignal,
 };
 
 use super::{
@@ -10,23 +11,23 @@ use super::{
 
 #[derive(Clone, Debug, Resource)]
 pub struct ParticleSpawnList {
-    particles: Vec<Particle>,
+    particles: Vec<ParticleType>,
     index: usize,
 }
 
 impl ParticleSpawnList {
-    pub fn new(particles: Vec<Particle>) -> Self {
+    pub fn new(particles: Vec<ParticleType>) -> Self {
         Self {
             particles,
             index: 0,
         }
     }
 
-    pub fn current(&self) -> Option<&Particle> {
+    pub fn current(&self) -> Option<&ParticleType> {
         self.particles.get(self.index)
     }
 
-    pub fn cycle_next(&mut self) -> Option<&Particle> {
+    pub fn cycle_next(&mut self) -> Option<&ParticleType> {
         if self.particles.is_empty() {
             return None;
         }
@@ -179,7 +180,7 @@ impl BrushType {
 }
 
 #[derive(Resource)]
-pub struct SelectedBrushParticle(pub Particle);
+pub struct SelectedBrushParticle(pub ParticleType);
 
 fn setup_brush(mut commands: Commands) {
     commands.spawn((
@@ -320,13 +321,16 @@ fn cycle_brush_type(
 fn sample_hovered(
     cursor: Res<Cursor>,
     chunk_map: Res<ParticleMap>,
-    particle_query: Query<&Particle>,
+    particle_query: Query<&AttachedToParticleType, With<Particle>>,
+    type_query: Query<&ParticleType>,
     mut selected_brush_particle: ResMut<SelectedBrushParticle>,
     mut brush_state: ResMut<NextState<BrushState>>,
 ) {
-    if let Ok(Some(entity)) = chunk_map.get_copied(cursor.current.as_ivec2()) {
-        let particle = particle_query.get(entity).unwrap();
-        selected_brush_particle.0 = particle.clone();
+    if let Ok(Some(entity)) = chunk_map.get_copied(cursor.current.as_ivec2())
+        && let Ok(attached) = particle_query.get(entity)
+        && let Ok(particle_type) = type_query.get(attached.0)
+    {
+        selected_brush_particle.0 = particle_type.clone();
         brush_state.set(BrushState::Spawn);
     }
 }

--- a/src/core/particle/lifecycle.rs
+++ b/src/core/particle/lifecycle.rs
@@ -1,24 +1,16 @@
-//! Provides mechanisms for ergonomic spawning/despawning of particle entities from the simulation
+//! Provides mechanisms for ergonomic spawning/despawning of particle entities from the simulation.
 //!
-//! Each of these are responsive to both messages and triggers
+//! Each of these are responsive to both messages and triggers:
 //! - [`SpawnParticleSignal`]: Spawn a new particle into the simulation
 //! - [`DespawnParticleSignal`]: Despawn a particle from the simulation
 //! - [`DespawnAllParticlesSignal`]: Despawn all particles from the simulation
-//! - [`DespawnParticleTypeChildrenSignal`]: Despawn all particle children of by name or parent
+//! - [`DespawnParticleTypeChildrenSignal`]: Despawn all particle children by name or parent
 //!   handle.
 //!
-//! Though it is possible to safely add and remove [`Particle`] entities from the world using
-//! [`Commands`] and inserting a [`Transform`] component, which often feels like the idiomatic
-//! approach, it is generally preferred to use the signals provided in this module.
-//!
-//! <div class="warning">
-//!
-//! Newly spawned [`Particle`] entities with a [`Transform`] will automatically have the
-//! [`Transform`] and its required components immediately removed to prevent overhead associated
-//! with rebuilding dirty trees when simulating many particles. `bfs` instead uses the
-//! [`GridPosition`] component for managing particle positions.
-//!
-//! </div>
+//! [`SpawnParticleSignal`] is the **only** supported way to introduce a particle into the
+//! simulation. Direct `commands.spawn(...)` of a [`Particle`] is not currently supported —
+//! the simulation relies on internal bookkeeping (`ParticleMap`, chunk dirty rects, parent
+//! resolution, sync propagation) that only the signal handlers wire up.
 
 use super::LocateBy;
 use crate::core::{
@@ -56,19 +48,7 @@ impl Plugin for LifecyclePlugin {
             )
             .add_systems(
                 PreUpdate,
-                (
-                    mark_positionless_particles_invalid,
-                    register_transform_particles,
-                    despawn_orphaned_particles,
-                )
-                    .chain()
-                    .before(ParticleSystems::Registration),
-            )
-            .add_systems(
-                PreUpdate,
-                (ApplyDeferred, despawn_invalid_particles)
-                    .chain()
-                    .after(ParticleSystems::Registration),
+                despawn_orphaned_particles.before(ParticleSystems::Registration),
             )
             .add_systems(
                 Update,
@@ -243,6 +223,12 @@ pub type OnSpawnCallback = Arc<dyn Fn(&mut EntityCommands) + Send + Sync>;
 /// - [`SpawnParticleSignal::try_multiple`] accepts an ordered list of desired spawn locations,
 ///   short-circuiting as soon as a vacancy is found.
 ///
+/// The signal carries a [`ParticleType`] value which is resolved to the matching parent entity via
+/// [`ParticleTypeRegistry`] at handle time. Spawned entities receive only the [`Particle`]
+/// marker plus an [`AttachedToParticleType`] reference. Therefore, when looking up a particle
+/// entity's type, the user should also query for [`ParticleType`] entities and look up the subject
+/// particle entity's [`AttachedToParticleType`].
+///
 /// # Hooking custom components during spawn
 ///
 /// Sometimes it may be desired to spawn a particle with additional behavior not managed by
@@ -263,14 +249,14 @@ pub type OnSpawnCallback = Arc<dyn Fn(&mut EntityCommands) + Send + Sync>;
 ///
 /// fn spawn_burning(mut writer: MessageWriter<SpawnParticleSignal>) {
 ///     writer.write(
-///         SpawnParticleSignal::new(Particle::new("Wood"), IVec2::new(5, 5))
+///         SpawnParticleSignal::new("Wood", IVec2::new(5, 5))
 ///             .with_on_spawn(|cmd| { cmd.insert(OnFire); }),
 ///     );
 /// }
 /// ```
 #[derive(Event, Message, Clone, Reflect, Serialize, Deserialize)]
 pub struct SpawnParticleSignal {
-    pub(crate) particle: Particle,
+    pub(crate) particle_type: ParticleType,
     pub(crate) positions: Vec<IVec2>,
     pub(crate) overwrite_existing: bool,
     #[serde(skip)]
@@ -281,7 +267,7 @@ pub struct SpawnParticleSignal {
 impl std::fmt::Debug for SpawnParticleSignal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SpawnParticleSignal")
-            .field("particle", &self.particle)
+            .field("particle_type", &self.particle_type)
             .field("positions", &self.positions)
             .field("overwrite_existing", &self.overwrite_existing)
             .field("on_spawn", &self.on_spawn.as_ref().map(|_| "..."))
@@ -300,15 +286,15 @@ impl SpawnParticleSignal {
     ///
     /// fn spawn(mut writer: MessageWriter<SpawnParticleSignal>) {
     ///     writer.write(SpawnParticleSignal::new(
-    ///         Particle::new("Sand"),
+    ///         "Sand",
     ///         IVec2::new(10, 20),
     ///     ));
     /// }
     /// ```
     #[must_use]
-    pub fn new(particle: Particle, position: IVec2) -> Self {
+    pub fn new(particle_type: impl Into<ParticleType>, position: IVec2) -> Self {
         Self {
-            particle,
+            particle_type: particle_type.into(),
             positions: vec![position],
             overwrite_existing: false,
             on_spawn: None,
@@ -325,15 +311,15 @@ impl SpawnParticleSignal {
     ///
     /// fn replace(mut writer: MessageWriter<SpawnParticleSignal>) {
     ///     writer.write(SpawnParticleSignal::overwrite_existing(
-    ///         Particle::new("Water"),
+    ///         "Water",
     ///         IVec2::new(10, 20),
     ///     ));
     /// }
     /// ```
     #[must_use]
-    pub fn overwrite_existing(particle: Particle, position: IVec2) -> Self {
+    pub fn overwrite_existing(particle_type: impl Into<ParticleType>, position: IVec2) -> Self {
         Self {
-            particle,
+            particle_type: particle_type.into(),
             positions: vec![position],
             overwrite_existing: true,
             on_spawn: None,
@@ -352,15 +338,15 @@ impl SpawnParticleSignal {
     /// // If position (11, 20) is vacant, short circuit and exit early.
     /// fn spawn_fallback(mut writer: MessageWriter<SpawnParticleSignal>) {
     ///     writer.write(SpawnParticleSignal::try_multiple(
-    ///         Particle::new("Sand"),
+    ///         "Sand",
     ///         vec![IVec2::new(10, 20), IVec2::new(11, 20), IVec2::new(12, 20)],
     ///     ));
     /// }
     /// ```
     #[must_use]
-    pub const fn try_multiple(particle: Particle, positions: Vec<IVec2>) -> Self {
+    pub fn try_multiple(particle_type: impl Into<ParticleType>, positions: Vec<IVec2>) -> Self {
         Self {
-            particle,
+            particle_type: particle_type.into(),
             positions,
             overwrite_existing: false,
             on_spawn: None,
@@ -387,7 +373,7 @@ impl SpawnParticleSignal {
     ///
     /// fn spawn_burning(mut writer: MessageWriter<SpawnParticleSignal>) {
     ///     writer.write(
-    ///         SpawnParticleSignal::new(Particle::new("Wood"), IVec2::new(5, 5))
+    ///         SpawnParticleSignal::new("Wood", IVec2::new(5, 5))
     ///             .with_on_spawn(|cmd| { cmd.insert(OnFire); }),
     ///     );
     /// }
@@ -561,25 +547,22 @@ fn msgr_spawn_particle(
 ) {
     use bevy::platform::collections::HashMap;
 
-    let mut pending_overwrites: HashMap<IVec2, (Particle, Entity, Option<OnSpawnCallback>)> =
+    let mut pending_overwrites: HashMap<IVec2, (Entity, Option<OnSpawnCallback>)> =
         HashMap::default();
     let mut spawned_positions: Vec<IVec2> = Vec::new();
 
     msgr_spawn_particle.read().for_each(|msg| {
-        if let Some(parent_handle) = registry.get(&msg.particle.name) {
+        if let Some(parent_handle) = registry.get(&msg.particle_type.name) {
             let on_spawn = msg.on_spawn.clone();
             for position in &msg.positions {
                 if msg.overwrite_existing {
-                    pending_overwrites.insert(
-                        *position,
-                        (msg.particle.clone(), *parent_handle, on_spawn.clone()),
-                    );
+                    pending_overwrites.insert(*position, (*parent_handle, on_spawn.clone()));
                 } else if map.is_position_loaded(*position) {
                     let on_spawn = on_spawn.clone();
                     if let Ok(mut entry) = map.entry(*position)
                         && entry.insert_if_vacant_with(|| {
                             let mut entity_commands = commands.spawn((
-                                msg.particle.clone(),
+                                Particle,
                                 GridPosition(*position),
                                 AttachedToParticleType(*parent_handle),
                             ));
@@ -597,9 +580,9 @@ fn msgr_spawn_particle(
         }
     });
 
-    for (position, (particle, parent_handle, on_spawn)) in pending_overwrites {
+    for (position, (parent_handle, on_spawn)) in pending_overwrites {
         let mut entity_commands = commands.spawn((
-            particle,
+            Particle,
             GridPosition(position),
             AttachedToParticleType(parent_handle),
         ));
@@ -641,25 +624,22 @@ fn on_spawn_particle(
 ) {
     use bevy::platform::collections::HashMap;
 
-    let mut pending_overwrites: HashMap<IVec2, (Particle, Entity, Option<OnSpawnCallback>)> =
+    let mut pending_overwrites: HashMap<IVec2, (Entity, Option<OnSpawnCallback>)> =
         HashMap::default();
     let mut spawned_positions: Vec<IVec2> = Vec::new();
 
     let event = trigger.event();
-    if let Some(parent_handle) = registry.get(&event.particle.name) {
+    if let Some(parent_handle) = registry.get(&event.particle_type.name) {
         let on_spawn = event.on_spawn.clone();
         for position in &event.positions {
             if event.overwrite_existing {
-                pending_overwrites.insert(
-                    *position,
-                    (event.particle.clone(), *parent_handle, on_spawn.clone()),
-                );
+                pending_overwrites.insert(*position, (*parent_handle, on_spawn.clone()));
             } else if map.is_position_loaded(*position) {
                 let on_spawn = on_spawn.clone();
                 if let Ok(mut entry) = map.entry(*position)
                     && entry.insert_if_vacant_with(|| {
                         let mut entity_commands = commands.spawn((
-                            event.particle.clone(),
+                            Particle,
                             GridPosition(*position),
                             AttachedToParticleType(*parent_handle),
                         ));
@@ -676,9 +656,9 @@ fn on_spawn_particle(
         }
     }
 
-    for (position, (particle, parent_handle, on_spawn)) in pending_overwrites {
+    for (position, (parent_handle, on_spawn)) in pending_overwrites {
         let mut entity_commands = commands.spawn((
-            particle,
+            Particle,
             GridPosition(position),
             AttachedToParticleType(parent_handle),
         ));
@@ -1005,87 +985,6 @@ fn despawn_orphaned_particles(
     }
 }
 
-/// Marker component for despawning invalid particles
-#[derive(Component)]
-pub struct InvalidParticle;
-
-/// Despawn particles with the [`InvalidParticle`] component.
-fn despawn_invalid_particles(mut commands: Commands, query: Query<Entity, With<InvalidParticle>>) {
-    for entity in &query {
-        commands.entity(entity).despawn();
-    }
-}
-
-/// Mark derelict particles as invalid
-fn mark_positionless_particles_invalid(
-    mut commands: Commands,
-    query: Query<Entity, (Added<Particle>, Without<Transform>, Without<GridPosition>)>,
-) {
-    for entity in &query {
-        warn!("Particle entity {entity} spawned without position. Removing from world");
-        commands.entity(entity).insert(InvalidParticle);
-    }
-}
-
-/// Registers newly added [`Particle`] entities with a [`Transform`] component with the
-/// [`ParticleMap`].
-///
-/// **Note**: [`Transform`] and its required components are removed after the particle has been
-/// registered. This is to avoid overhead associated with Bevy's transform systems, which
-/// becomes noticeable when the simulation is managing large numbers of particles.
-#[allow(clippy::needless_pass_by_value)]
-fn register_transform_particles(
-    mut commands: Commands,
-    mut map: ResMut<ParticleMap>,
-    registry: Res<ParticleTypeRegistry>,
-    chunk_index: Res<ChunkIndex>,
-    mut chunk_query: Query<&mut ChunkDirtyState>,
-    mut particle_query: Query<
-        (Entity, &Particle, &Transform),
-        (Added<Particle>, Without<GridPosition>),
-    >,
-) {
-    for (entity, particle, transform) in &mut particle_query {
-        let position = IVec2::new(
-            transform.translation.x.round() as i32,
-            transform.translation.y.round() as i32,
-        );
-
-        let Some(parent_handle) = registry.get(&particle.name).copied() else {
-            warn!(
-                "Particle '{}' not found in registry - marking invalid",
-                particle.name
-            );
-            commands.entity(entity).insert(InvalidParticle);
-            continue;
-        };
-
-        let Ok(mut entry) = map.entry(position) else {
-            commands.entity(entity).insert(InvalidParticle);
-            continue;
-        };
-
-        if entry.insert_if_vacant(entity) {
-            commands
-                .entity(entity)
-                .insert((
-                    GridPosition(position),
-                    AttachedToParticleType(parent_handle),
-                ))
-                .remove::<(Transform, GlobalTransform, TransformTreeChanged)>();
-
-            let chunk_coord = chunk_index.world_to_chunk_coord(position);
-            if let Some(chunk_entity) = chunk_index.get(chunk_coord)
-                && let Ok(mut dirty_state) = chunk_query.get_mut(chunk_entity)
-            {
-                dirty_state.mark_dirty(position);
-            }
-        } else {
-            commands.entity(entity).insert(InvalidParticle);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -1094,8 +993,8 @@ mod tests {
     use crate::{
         FallingSandMinimalPlugin,
         core::{
-            AttachedToParticleType, ChanceLifetime, ChunkLoader, GridPosition, Particle,
-            ParticleMap, ParticleSyncExt, ParticleType, ParticleTypeRegistry, TimedLifetime,
+            AttachedToParticleType, ChanceLifetime, GridPosition, Particle, ParticleMap,
+            ParticleType, ParticleTypeRegistry, TimedLifetime,
         },
     };
 
@@ -1107,6 +1006,20 @@ mod tests {
         app.add_plugins(MinimalPlugins);
         app.add_plugins(FallingSandMinimalPlugin::default());
         app
+    }
+
+    fn name_of(app: &App, entity: Entity) -> String {
+        let attached = app
+            .world()
+            .entity(entity)
+            .get::<AttachedToParticleType>()
+            .unwrap();
+        app.world()
+            .entity(attached.0)
+            .get::<ParticleType>()
+            .unwrap()
+            .name
+            .to_string()
     }
 
     // ---- particle_type hooks ----
@@ -1166,7 +1079,7 @@ mod tests {
 
         let position = IVec2::new(3, 4);
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let map = app.world().resource::<ParticleMap>();
@@ -1175,8 +1088,7 @@ mod tests {
             .unwrap()
             .expect("Particle should exist in map");
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "sand");
+        assert_eq!(name_of(&app, entity), "sand");
 
         let grid_pos = app.world().entity(entity).get::<GridPosition>().unwrap();
         assert_eq!(grid_pos.0, position);
@@ -1193,7 +1105,7 @@ mod tests {
         let position = IVec2::ZERO;
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let first_entity = app
@@ -1204,7 +1116,7 @@ mod tests {
             .unwrap();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("water"), position));
+            .write_message(SpawnParticleSignal::new("water", position));
         app.update();
 
         let entity = app
@@ -1215,8 +1127,7 @@ mod tests {
             .unwrap();
         assert_eq!(entity, first_entity);
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "sand");
+        assert_eq!(name_of(&app, entity), "sand");
     }
 
     #[test]
@@ -1230,7 +1141,7 @@ mod tests {
         let position = IVec2::ZERO;
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let old_entity = app
@@ -1241,10 +1152,7 @@ mod tests {
             .unwrap();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::overwrite_existing(
-                Particle::new("water"),
-                position,
-            ));
+            .write_message(SpawnParticleSignal::overwrite_existing("water", position));
         app.update();
 
         let new_entity = app
@@ -1257,8 +1165,7 @@ mod tests {
         assert_ne!(old_entity, new_entity);
         assert!(!app.world().entities().contains(old_entity));
 
-        let particle = app.world().entity(new_entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "water");
+        assert_eq!(name_of(&app, new_entity), "water");
     }
 
     #[test]
@@ -1273,12 +1180,12 @@ mod tests {
         let pos_b = IVec2::new(1, 0);
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), pos_a));
+            .write_message(SpawnParticleSignal::new("sand", pos_a));
         app.update();
 
         app.world_mut()
             .write_message(SpawnParticleSignal::try_multiple(
-                Particle::new("water"),
+                "water",
                 vec![pos_a, pos_b],
             ));
         app.update();
@@ -1286,16 +1193,10 @@ mod tests {
         let map = app.world().resource::<ParticleMap>();
 
         let entity_a = map.get_copied(pos_a).unwrap().unwrap();
-        assert_eq!(
-            app.world().entity(entity_a).get::<Particle>().unwrap().name,
-            "sand"
-        );
+        assert_eq!(name_of(&app, entity_a), "sand");
 
         let entity_b = map.get_copied(pos_b).unwrap().unwrap();
-        assert_eq!(
-            app.world().entity(entity_b).get::<Particle>().unwrap().name,
-            "water"
-        );
+        assert_eq!(name_of(&app, entity_b), "water");
     }
 
     #[test]
@@ -1305,11 +1206,12 @@ mod tests {
         app.world_mut().spawn(ParticleType::new("sand"));
         app.update();
 
-        app.world_mut().write_message(
-            SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO).with_on_spawn(|cmd| {
-                cmd.insert(Marker(99));
-            }),
-        );
+        app.world_mut()
+            .write_message(
+                SpawnParticleSignal::new("sand", IVec2::ZERO).with_on_spawn(|cmd| {
+                    cmd.insert(Marker(99));
+                }),
+            );
         app.update();
 
         let particle_entity = app
@@ -1330,10 +1232,8 @@ mod tests {
         let mut app = create_test_app();
         app.update();
 
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("ghost"),
-            IVec2::ZERO,
-        ));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("ghost", IVec2::ZERO));
         app.update();
 
         let count = app
@@ -1355,7 +1255,7 @@ mod tests {
 
         let position = IVec2::ZERO;
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let entity = app
@@ -1383,7 +1283,7 @@ mod tests {
 
         let position = IVec2::ZERO;
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let entity = app
@@ -1413,7 +1313,7 @@ mod tests {
 
         let position = IVec2::ZERO;
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let entity = app
@@ -1442,27 +1342,23 @@ mod tests {
         app.update();
 
         for i in 0..5 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("water"),
-            IVec2::new(10, 0),
-        ));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("water", IVec2::new(10, 0)));
         app.update();
 
         app.world_mut()
             .write_message(DespawnParticleTypeChildrenSignal::from_name("sand"));
         app.update();
 
-        let remaining: Vec<String> = app
+        let entities: Vec<Entity> = app
             .world_mut()
-            .query::<&Particle>()
+            .query_filtered::<Entity, With<Particle>>()
             .iter(app.world())
-            .map(|p| p.name.to_string())
             .collect();
+        let remaining: Vec<String> = entities.iter().map(|&e| name_of(&app, e)).collect();
 
         assert_eq!(remaining, vec!["water"]);
     }
@@ -1476,15 +1372,11 @@ mod tests {
         app.update();
 
         for i in 0..3 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("water"),
-            IVec2::new(10, 0),
-        ));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("water", IVec2::new(10, 0)));
         app.update();
 
         app.world_mut()
@@ -1493,12 +1385,12 @@ mod tests {
             ));
         app.update();
 
-        let remaining: Vec<String> = app
+        let entities: Vec<Entity> = app
             .world_mut()
-            .query::<&Particle>()
+            .query_filtered::<Entity, With<Particle>>()
             .iter(app.world())
-            .map(|p| p.name.to_string())
             .collect();
+        let remaining: Vec<String> = entities.iter().map(|&e| name_of(&app, e)).collect();
 
         assert_eq!(remaining, vec!["water"]);
     }
@@ -1515,15 +1407,11 @@ mod tests {
 
         let mut entities = vec![];
         for i in 0..5 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("water"),
-            IVec2::new(10, 0),
-        ));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("water", IVec2::new(10, 0)));
         app.update();
 
         entities.extend(
@@ -1543,125 +1431,6 @@ mod tests {
         }
     }
 
-    // ---- register_transform_particles ----
-
-    fn load_chunk_at_origin(app: &mut App) {
-        app.world_mut().spawn((ChunkLoader, Transform::default()));
-        app.update();
-    }
-
-    #[test]
-    fn register_transform_particle_with_position() {
-        let mut app = create_test_app();
-        load_chunk_at_origin(&mut app);
-
-        app.world_mut().spawn(ParticleType::new("sand"));
-        app.update();
-
-        let entity = app
-            .world_mut()
-            .commands()
-            .spawn((Particle::new("sand"), Transform::from_xyz(0., 0., 0.)))
-            .id();
-        app.update();
-
-        assert!(app.world().entities().contains(entity));
-        assert!(app.world().entity(entity).get::<GridPosition>().is_some());
-        assert!(
-            app.world()
-                .entity(entity)
-                .get::<AttachedToParticleType>()
-                .is_some()
-        );
-    }
-
-    #[test]
-    fn register_transform_particle_rounds_position() {
-        let mut app = create_test_app();
-        load_chunk_at_origin(&mut app);
-
-        app.world_mut().spawn(ParticleType::new("sand"));
-        app.update();
-
-        let entity = app
-            .world_mut()
-            .commands()
-            .spawn((Particle::new("sand"), Transform::from_xyz(0.7, -0.3, 0.)))
-            .id();
-        app.update();
-
-        let grid_position = app
-            .world()
-            .entity(entity)
-            .get::<GridPosition>()
-            .expect("GridPosition should be assigned");
-        assert_eq!(grid_position.0, IVec2::new(1, 0));
-
-        assert!(
-            app.world().entity(entity).get::<Transform>().is_none(),
-            "Transform should be removed after registration"
-        );
-    }
-
-    #[test]
-    fn register_transform_particle_without_position_is_despawned() {
-        let mut app = create_test_app();
-        load_chunk_at_origin(&mut app);
-
-        app.world_mut().spawn(ParticleType::new("sand"));
-        app.update();
-
-        let entity = app.world_mut().spawn(Particle::new("sand")).id();
-        app.update();
-
-        assert!(
-            !app.world().entities().contains(entity),
-            "Positionless particle should be despawned"
-        );
-    }
-
-    #[test]
-    fn register_transform_particle_propagates_components() {
-        let mut app = create_test_app();
-        app.register_particle_sync_component::<Marker>();
-        load_chunk_at_origin(&mut app);
-
-        app.world_mut()
-            .spawn((ParticleType::new("sand"), Marker(42)));
-        app.update();
-
-        let entity = app
-            .world_mut()
-            .commands()
-            .spawn((Particle::new("sand"), Transform::from_xyz(0., 0., 0.)))
-            .id();
-        app.update();
-
-        assert_eq!(
-            app.world().entity(entity).get::<Marker>(),
-            Some(&Marker(42)),
-            "Registered component should propagate from ParticleType"
-        );
-    }
-
-    #[test]
-    fn register_transform_particle_unregistered_type_is_despawned() {
-        let mut app = create_test_app();
-        load_chunk_at_origin(&mut app);
-
-        let entity = app
-            .world_mut()
-            .commands()
-            .spawn((Particle::new("ghost"), Transform::from_xyz(0., 0., 0.)))
-            .id();
-        app.update();
-
-        assert!(
-            !app.world().entities().contains(entity),
-            "Particle with unregistered type should be despawned"
-        );
-    }
-
     // ---- despawn_orphaned_particles ----
 
     #[test]
@@ -1673,10 +1442,8 @@ mod tests {
 
         let mut particle_entities = vec![];
         for i in 0..5 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
         app.update();
 
@@ -1715,15 +1482,11 @@ mod tests {
         app.update();
 
         for i in 0..3 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("water"),
-            IVec2::new(10, 0),
-        ));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("water", IVec2::new(10, 0)));
         app.update();
 
         let water_entity = app
@@ -1737,14 +1500,7 @@ mod tests {
         app.update();
 
         assert!(app.world().entities().contains(water_entity));
-        assert_eq!(
-            app.world()
-                .entity(water_entity)
-                .get::<Particle>()
-                .unwrap()
-                .name,
-            "water"
-        );
+        assert_eq!(name_of(&app, water_entity), "water");
 
         let map = app.world().resource::<ParticleMap>();
         for i in 0..3 {
@@ -1756,7 +1512,7 @@ mod tests {
 
     fn spawn_particle_at(app: &mut App, name: &'static str, position: IVec2) -> Entity {
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new(name), position));
+            .write_message(SpawnParticleSignal::new(name, position));
         app.update();
 
         app.world()

--- a/src/core/particle/mod.rs
+++ b/src/core/particle/mod.rs
@@ -174,14 +174,34 @@ impl From<ParticleType> for Cow<'static, str> {
     }
 }
 
-/// Define an entity as a `Particle`.
+/// Marker component for entities participating in the falling sand simulation.
 ///
-/// `Particle` acts as a marker comopnent for particles which are actively being simulated.
+/// `Particle` is a zero-sized component. The "type" of a particle is identified entirely by its
+/// [`AttachedToParticleType`] reference, which points at the [`ParticleType`] entity that holds
+/// the canonical name and shared-default behavior. To read a particle's type name, query its
+/// parent:
 ///
-/// When a `Particle` changes its name, it will automatically synchronize with an associated
-/// [`ParticleType`] entity.
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_falling_sand::core::{AttachedToParticleType, Particle, ParticleType};
+///
+/// fn read_names(
+///     particles: Query<&AttachedToParticleType, With<Particle>>,
+///     types: Query<&ParticleType>,
+/// ) {
+///     for attached in &particles {
+///         if let Ok(particle_type) = types.get(attached.0) {
+///             println!("{}", particle_type.name);
+///         }
+///     }
+/// }
+/// ```
+///
+/// To re-type a particle (change which [`ParticleType`] it belongs to), look up the new parent
+/// in [`ParticleTypeRegistry`] and assign its entity directly to [`AttachedToParticleType`].
 #[derive(
     Component,
+    Copy,
     Clone,
     Default,
     Eq,
@@ -197,11 +217,7 @@ impl From<ParticleType> for Cow<'static, str> {
 #[component(on_remove = Particle::on_remove)]
 #[reflect(Component)]
 #[type_path = "bfs_core::particle"]
-pub struct Particle {
-    /// The name of the particle, which corresponds to its [`ParticleType`] and can be used as an
-    /// index in the  [`ParticleTypeRegistry`] resource.
-    pub name: Cow<'static, str>,
-}
+pub struct Particle;
 
 impl Particle {
     fn on_remove(mut world: DeferredWorld, context: HookContext) {
@@ -225,77 +241,6 @@ impl Particle {
         if let Some(mut dirty_state) = world.get_mut::<crate::core::ChunkDirtyState>(chunk_entity) {
             dirty_state.mark_dirty(position);
         }
-    }
-
-    /// Initialize a new `Particle` from a static string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_falling_sand::core::Particle;
-    ///
-    /// let sand = Particle::new("Sand");
-    /// assert_eq!(sand.name, "Sand");
-    /// ```
-    #[must_use]
-    pub const fn new(name: &'static str) -> Self {
-        Self {
-            name: Cow::Borrowed(name),
-        }
-    }
-
-    /// Initialize a new `Particle` from an owned string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_falling_sand::core::Particle;
-    ///
-    /// let name = String::from("Water");
-    /// let water = Particle::from_string(name);
-    /// assert_eq!(water.name, "Water");
-    /// ```
-    #[must_use]
-    pub const fn from_string(name: String) -> Self {
-        Self {
-            name: Cow::Owned(name),
-        }
-    }
-}
-
-impl From<&'static str> for Particle {
-    fn from(name: &'static str) -> Self {
-        Self::new(name)
-    }
-}
-
-impl From<String> for Particle {
-    fn from(name: String) -> Self {
-        Self::from_string(name)
-    }
-}
-
-impl From<Cow<'static, str>> for Particle {
-    fn from(name: Cow<'static, str>) -> Self {
-        Self { name }
-    }
-}
-
-impl From<Particle> for Cow<'static, str> {
-    fn from(value: Particle) -> Self {
-        value.name
-    }
-}
-
-impl From<ParticleType> for Particle {
-    fn from(value: ParticleType) -> Self {
-        Self { name: value.name }
-    }
-}
-
-impl From<Particle> for ParticleType {
-    fn from(value: Particle) -> Self {
-        Self { name: value.name }
     }
 }
 

--- a/src/core/particle/sync.rs
+++ b/src/core/particle/sync.rs
@@ -4,7 +4,8 @@
 //! A `Particle` will synchronize with its parent on 2 occasions:
 //! - A [`SyncParticleSignal`] has been received (sent explicitly or via
 //!   [`SyncParticleTypeChildrenSignal`]).
-//! - `Changed<Particle>` fires (e.g., on spawn or when [`Particle::name`] is mutated).
+//! - `Changed<AttachedToParticleType>` fires (e.g., on spawn or when a [`ChanceMutation`]
+//!   re-attaches a particle to a new parent).
 //!
 //! The [`ParticleSyncExt`] trait provides an interface for adding your own particle sync
 //! components. Each registered propagator is keyed by a [`TypeId`], enabling
@@ -19,7 +20,7 @@ use crate::core::{
 use bevy::{ecs::system::SystemParam, platform::collections::HashSet, prelude::*};
 use bevy_turborand::{DelegatedRng, GlobalRng};
 use serde::{Deserialize, Serialize};
-use std::{any::TypeId, borrow::Cow, time::Duration};
+use std::{any::TypeId, time::Duration};
 
 pub(super) struct SyncPlugin;
 
@@ -35,8 +36,6 @@ impl Plugin for SyncPlugin {
                 PreUpdate,
                 (
                     sync_particle_type_registry,
-                    sync_particle_type_children_names.after(sync_particle_type_registry),
-                    sync_particle_parent.after(sync_particle_type_children_names),
                     msgr_sync_particle_type_children,
                 )
                     .before(ParticleSystems::Registration),
@@ -55,20 +54,20 @@ impl Plugin for SyncPlugin {
     }
 }
 
-/// A chance-based mutation component that has a chance to rename a [`Particle`] to a target
-/// type on a per-tick basis.
+/// A chance-based mutation component that has a chance to re-type a [`Particle`] on a per-tick
+/// basis.
 ///
-/// When the roll succeeds, the [`Particle::name`] is updated to [`ChanceMutation::target`].
-/// The change triggers normal particle synchronization, so the particle is re-attached to its
-/// new [`ParticleType`] and registered components are re-propagated. If `target` does not
-/// match a registered [`ParticleType`], the mutation is reverted by internal synchronization
-/// systems.
+/// When the roll succeeds, the particle's [`AttachedToParticleType`] is swapped to point at the
+/// [`ParticleType`] entity registered under [`ChanceMutation::target`]. The change triggers
+/// normal particle synchronization, so all registered components are re-propagated from the new
+/// parent. If `target` does not match a registered [`ParticleType`], the mutation is silently
+/// skipped.
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Component)]
 #[type_path = "bfs_core::particle"]
 pub struct ChanceMutation {
-    /// The name of the [`ParticleType`] this particle should mutate into.
-    pub target: Cow<'static, str>,
+    /// The [`ParticleType`] this particle should mutate into.
+    pub target: ParticleType,
     /// The probability (0.0 to 1.0) that the particle will mutate each tick.
     pub chance: f64,
     /// Timer that controls how often the chance is evaluated.
@@ -78,7 +77,7 @@ pub struct ChanceMutation {
 impl Default for ChanceMutation {
     fn default() -> Self {
         Self {
-            target: Cow::Borrowed(""),
+            target: ParticleType::default(),
             chance: 0.0,
             tick_timer: Timer::new(Duration::ZERO, TimerMode::Repeating),
         }
@@ -86,7 +85,10 @@ impl Default for ChanceMutation {
 }
 
 impl ChanceMutation {
-    /// Create a new chance-based mutation targeting `target` from a static string.
+    /// Create a new chance-based mutation targeting `target`.
+    ///
+    /// Accepts anything convertible into [`ParticleType`] — `&'static str` literals, owned
+    /// `String`s, and `ParticleType` values all work.
     ///
     /// # Examples
     ///
@@ -95,34 +97,13 @@ impl ChanceMutation {
     /// use bevy_falling_sand::core::ChanceMutation;
     ///
     /// let mutation = ChanceMutation::new("Water", 0.05, Duration::from_millis(100));
-    /// assert_eq!(mutation.target, "Water");
+    /// assert_eq!(mutation.target.name, "Water");
     /// assert_eq!(mutation.chance, 0.05);
     /// ```
     #[must_use]
-    pub fn new(target: &'static str, chance: f64, tick_rate: Duration) -> Self {
+    pub fn new(target: impl Into<ParticleType>, chance: f64, tick_rate: Duration) -> Self {
         Self {
-            target: Cow::Borrowed(target),
-            chance,
-            tick_timer: Timer::new(tick_rate, TimerMode::Repeating),
-        }
-    }
-
-    /// Create a new chance-based mutation targeting `target` from an owned string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::time::Duration;
-    /// use bevy_falling_sand::core::ChanceMutation;
-    ///
-    /// let target = String::from("Water");
-    /// let mutation = ChanceMutation::from_string(target, 0.05, Duration::from_millis(100));
-    /// assert_eq!(mutation.target, "Water");
-    /// ```
-    #[must_use]
-    pub fn from_string(target: String, chance: f64, tick_rate: Duration) -> Self {
-        Self {
-            target: Cow::Owned(target),
+            target: target.into(),
             chance,
             tick_timer: Timer::new(tick_rate, TimerMode::Repeating),
         }
@@ -131,16 +112,18 @@ impl ChanceMutation {
 
 #[allow(clippy::needless_pass_by_value)]
 fn handle_chance_mutations(
-    mut query: Query<(&mut Particle, &mut ChanceMutation)>,
+    mut query: Query<(&mut AttachedToParticleType, &mut ChanceMutation), With<Particle>>,
+    registry: Res<ParticleTypeRegistry>,
     mut rng: ResMut<GlobalRng>,
     time: Res<Time>,
 ) {
-    for (mut particle, mut mutation) in &mut query {
+    for (mut attached, mut mutation) in &mut query {
         if mutation.tick_timer.tick(time.delta()).just_finished()
             && rng.chance(mutation.chance)
-            && particle.name != mutation.target
+            && let Some(&new_parent) = registry.get(&mutation.target.name)
+            && attached.0 != new_parent
         {
-            particle.name.clone_from(&mutation.target);
+            attached.0 = new_parent;
         }
     }
 }
@@ -205,9 +188,9 @@ impl ParticlePropagators {
 /// your own components the same way.
 ///
 /// Propagators run during component synchronization whenever a [`SyncParticleSignal`] is
-/// received or [`Particle`] change detection fires (e.g. on spawn or when [`Particle::name`] is
-/// mutated). Each propagator receives the particle entity, its parent [`ParticleType`] entity,
-/// and [`Commands`] for deferred mutations.
+/// received or change detection on [`AttachedToParticleType`] fires (e.g. on spawn or when a
+/// [`ChanceMutation`] re-attaches a particle to a new parent). Each propagator receives the
+/// particle entity, its parent [`ParticleType`] entity, and [`Commands`] for deferred mutations.
 ///
 /// Every propagator is keyed by a [`TypeId`], which enables selective
 /// synchronization via [`PropagatorFilter`]. Signals can target specific propagators with
@@ -346,9 +329,10 @@ impl ParticleSyncExt for App {
 /// Synchronizes [`Particle`] components with their [`ParticleType`] parent's components.
 ///
 /// Targets are collected from two sources, deduplicated by entity:
-/// 1. Drained [`SyncParticleSignal`] messages (sent externally or other internal sync related triggers)
-/// 2. `Changed<Particle>` query (catches freshly spawned particles whose deferred commands
-///    were applied after `sync_particle_parent` already ran in the same frame)
+/// 1. Drained [`SyncParticleSignal`] messages (sent externally or by other internal triggers)
+/// 2. `Changed<AttachedToParticleType>` query (catches freshly spawned particles and
+///    [`ChanceMutation`] re-attachments — any time the parent reference changes, we need to
+///    re-propagate components from the new parent)
 #[derive(SystemParam)]
 struct SyncParticleParams<'w, 's> {
     msgr: MessageReader<'w, 's, SyncParticleSignal>,
@@ -361,7 +345,7 @@ struct SyncParticleParams<'w, 's> {
             &'static AttachedToParticleType,
             &'static GridPosition,
         ),
-        (Changed<Particle>, With<Particle>),
+        (Changed<AttachedToParticleType>, With<Particle>),
     >,
     particle_map: Res<'w, ParticleMap>,
     propagators: Res<'w, ParticlePropagators>,
@@ -773,58 +757,6 @@ fn sync_particle_type_registry(
     }
 }
 
-/// Propagates [`ParticleType`] name changes to all living child [`Particle`] entities.
-///
-/// When a `ParticleType` name is updated, its children still hold the old name in their
-/// [`Particle`] component. This system finds all children via [`AttachedToParticleType`] and
-/// updates their names to match the parent.
-fn sync_particle_type_children_names(
-    parent_query: Query<(Entity, &ParticleType), Changed<ParticleType>>,
-    mut child_query: Query<(&mut Particle, &AttachedToParticleType)>,
-) {
-    for (parent_entity, particle_type) in &parent_query {
-        for (mut particle, attached) in &mut child_query {
-            if attached.0 == parent_entity && particle.name != particle_type.name {
-                particle.name.clone_from(&particle_type.name);
-            }
-        }
-    }
-}
-
-/// Synchronizes a [`Particle`] with its parent [`ParticleType`] if change detection fires for
-/// a `Particle`. If the new name doesn't match any registered [`ParticleType`], the change is
-/// reverted and a warning is issued.
-#[allow(clippy::needless_pass_by_value)]
-fn sync_particle_parent(
-    mut commands: Commands,
-    mut particle_query: Query<
-        (Entity, &mut Particle, &AttachedToParticleType),
-        (Changed<Particle>, With<GridPosition>),
-    >,
-    registry: Res<ParticleTypeRegistry>,
-    particle_type_query: Query<&ParticleType>,
-) {
-    for (entity, mut particle, current_parent) in &mut particle_query {
-        if let Some(new_parent_handle) = registry.get(&particle.name) {
-            if current_parent.0 != *new_parent_handle {
-                commands
-                    .entity(entity)
-                    .insert(AttachedToParticleType(*new_parent_handle));
-            }
-        } else if let Ok(parent_type) = particle_type_query.get(current_parent.0) {
-            warn!(
-                "Particle name '{}' does not match any registered ParticleType, \
-                 reverting to '{}'",
-                particle.name, parent_type.name
-            );
-            particle
-                .bypass_change_detection()
-                .name
-                .clone_from(&parent_type.name);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -875,93 +807,6 @@ mod tests {
         assert_eq!(registry.get("sand"), None);
     }
 
-    // ---- sync_particle_parent ----
-
-    #[test]
-    fn sync_particle_parent_updates_attached_on_particle_mutation() {
-        let mut app = create_test_app();
-
-        let sand_pt = app.world_mut().spawn(ParticleType::new("sand")).id();
-        let water_pt = app.world_mut().spawn(ParticleType::new("water")).id();
-        app.update();
-
-        app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
-        app.update();
-
-        let particle_entity = app
-            .world_mut()
-            .query_filtered::<Entity, With<Particle>>()
-            .iter(app.world())
-            .next()
-            .unwrap();
-
-        let attached = app
-            .world()
-            .entity(particle_entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, sand_pt);
-
-        app.world_mut()
-            .entity_mut(particle_entity)
-            .get_mut::<Particle>()
-            .unwrap()
-            .name = "water".into();
-        app.update();
-        app.update();
-
-        let attached = app
-            .world()
-            .entity(particle_entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, water_pt);
-    }
-
-    #[test]
-    fn sync_particle_parent_reverts_unregistered_name() {
-        let mut app = create_test_app();
-
-        let sand_pt = app.world_mut().spawn(ParticleType::new("sand")).id();
-        app.update();
-
-        app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
-        app.update();
-
-        let particle_entity = app
-            .world_mut()
-            .query_filtered::<Entity, With<Particle>>()
-            .iter(app.world())
-            .next()
-            .unwrap();
-
-        app.world_mut()
-            .entity_mut(particle_entity)
-            .get_mut::<Particle>()
-            .unwrap()
-            .name = "ghost".into();
-        app.update();
-
-        let particle = app
-            .world()
-            .entity(particle_entity)
-            .get::<Particle>()
-            .unwrap();
-        assert_eq!(
-            particle.name, "sand",
-            "Name should revert to parent ParticleType"
-        );
-
-        let attached = app
-            .world()
-            .entity(particle_entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, sand_pt);
-    }
-
     // ---- sync_registered_components ----
 
     #[test]
@@ -974,7 +819,7 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -999,11 +844,11 @@ mod tests {
 
         app.world_mut()
             .spawn((ParticleType::new("sand"), Marker(42)));
-        app.world_mut().spawn(ParticleType::new("water"));
+        let water_pt = app.world_mut().spawn(ParticleType::new("water")).id();
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -1022,9 +867,9 @@ mod tests {
 
         app.world_mut()
             .entity_mut(particle_entity)
-            .get_mut::<Particle>()
+            .get_mut::<AttachedToParticleType>()
             .unwrap()
-            .name = "water".into();
+            .0 = water_pt;
         app.update();
         app.update();
 
@@ -1042,12 +887,14 @@ mod tests {
 
         app.world_mut()
             .spawn((ParticleType::new("sand"), Marker(1)));
-        app.world_mut()
-            .spawn((ParticleType::new("water"), Marker(2)));
+        let water_pt = app
+            .world_mut()
+            .spawn((ParticleType::new("water"), Marker(2)))
+            .id();
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -1064,9 +911,9 @@ mod tests {
 
         app.world_mut()
             .entity_mut(particle_entity)
-            .get_mut::<Particle>()
+            .get_mut::<AttachedToParticleType>()
             .unwrap()
-            .name = "water".into();
+            .0 = water_pt;
         app.update();
         app.update();
 
@@ -1091,7 +938,7 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -1138,7 +985,7 @@ mod tests {
 
         let position = IVec2::new(5, 5);
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), position));
+            .write_message(SpawnParticleSignal::new("sand", position));
         app.update();
 
         let particle_entity = app
@@ -1175,10 +1022,8 @@ mod tests {
         app.update();
 
         for i in 0..5 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
         app.update();
 
@@ -1222,10 +1067,8 @@ mod tests {
         app.update();
 
         for i in 0..3 {
-            app.world_mut().write_message(SpawnParticleSignal::new(
-                Particle::new("sand"),
-                IVec2::new(i, 0),
-            ));
+            app.world_mut()
+                .write_message(SpawnParticleSignal::new("sand", IVec2::new(i, 0)));
         }
         app.update();
 
@@ -1264,11 +1107,9 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("water"),
-            IVec2::new(1, 0),
-        ));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("water", IVec2::new(1, 0)));
         app.update();
 
         app.world_mut().entity_mut(sand_pt).insert(Marker(99));
@@ -1279,20 +1120,31 @@ mod tests {
         app.update();
         app.update();
 
-        let particles: Vec<(Particle, Marker)> = app
+        let particles: Vec<(Entity, Marker)> = app
             .world_mut()
-            .query::<(&Particle, &Marker)>()
+            .query_filtered::<(Entity, &Marker), With<Particle>>()
             .iter(app.world())
-            .map(|(p, m)| (p.clone(), m.clone()))
+            .map(|(e, m)| (e, m.clone()))
             .collect();
+
+        let type_name = |entity: Entity| -> Option<String> {
+            let attached = app.world().entity(entity).get::<AttachedToParticleType>()?;
+            Some(
+                app.world()
+                    .entity(attached.0)
+                    .get::<ParticleType>()?
+                    .name
+                    .to_string(),
+            )
+        };
 
         let sand_marker = particles
             .iter()
-            .find(|(p, _)| p.name == "sand")
+            .find(|(e, _)| type_name(*e).as_deref() == Some("sand"))
             .map(|(_, m)| m);
         let water_marker = particles
             .iter()
-            .find(|(p, _)| p.name == "water")
+            .find(|(e, _)| type_name(*e).as_deref() == Some("water"))
             .map(|(_, m)| m);
 
         assert_eq!(sand_marker, Some(&Marker(99)));
@@ -1316,7 +1168,7 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -1370,7 +1222,7 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
         app.update();
 
         let particle_entity = app
@@ -1415,11 +1267,9 @@ mod tests {
         app.update();
 
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new("sand"), IVec2::ZERO));
-        app.world_mut().write_message(SpawnParticleSignal::new(
-            Particle::new("sand"),
-            IVec2::new(1, 0),
-        ));
+            .write_message(SpawnParticleSignal::new("sand", IVec2::ZERO));
+        app.world_mut()
+            .write_message(SpawnParticleSignal::new("sand", IVec2::new(1, 0)));
         app.update();
 
         let particle_entities: Vec<Entity> = app
@@ -1463,7 +1313,7 @@ mod tests {
 
     fn spawn_particle_at(app: &mut App, name: &'static str, position: IVec2) -> Entity {
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new(name), position));
+            .write_message(SpawnParticleSignal::new(name, position));
         app.update();
 
         app.world()
@@ -1473,34 +1323,41 @@ mod tests {
             .unwrap()
     }
 
+    fn attached_to(app: &App, entity: Entity) -> Entity {
+        app.world()
+            .entity(entity)
+            .get::<AttachedToParticleType>()
+            .unwrap()
+            .0
+    }
+
     #[test]
     fn chance_mutation_default() {
         let mutation = ChanceMutation::default();
-        assert_eq!(mutation.target, "");
+        assert_eq!(mutation.target.name, "");
         assert_eq!(mutation.chance, 0.0);
         assert_eq!(mutation.tick_timer.duration(), Duration::ZERO);
     }
 
     #[test]
-    fn chance_mutation_new() {
+    fn chance_mutation_new_from_static_str() {
         let mutation = ChanceMutation::new("water", 0.5, Duration::from_millis(100));
-        assert_eq!(mutation.target, "water");
+        assert_eq!(mutation.target.name, "water");
         assert_eq!(mutation.chance, 0.5);
         assert_eq!(mutation.tick_timer.duration(), Duration::from_millis(100));
     }
 
     #[test]
-    fn chance_mutation_from_string() {
-        let mutation =
-            ChanceMutation::from_string("water".to_string(), 0.5, Duration::from_millis(100));
-        assert_eq!(mutation.target, "water");
+    fn chance_mutation_new_from_owned_string() {
+        let mutation = ChanceMutation::new("water".to_string(), 0.5, Duration::from_millis(100));
+        assert_eq!(mutation.target.name, "water");
         assert_eq!(mutation.chance, 0.5);
     }
 
     #[test]
     fn chance_mutation_zero_never_mutates() {
         let mut app = create_test_app();
-        app.world_mut().spawn(ParticleType::new("sand"));
+        let sand_pt = app.world_mut().spawn(ParticleType::new("sand")).id();
         app.world_mut().spawn(ParticleType::new("water"));
         app.update();
 
@@ -1515,8 +1372,7 @@ mod tests {
             app.update();
         }
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "sand");
+        assert_eq!(attached_to(&app, entity), sand_pt);
     }
 
     #[test]
@@ -1528,13 +1384,7 @@ mod tests {
 
         let position = IVec2::ZERO;
         let entity = spawn_particle_at(&mut app, "sand", position);
-
-        let attached = app
-            .world()
-            .entity(entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, sand_pt);
+        assert_eq!(attached_to(&app, entity), sand_pt);
 
         app.world_mut()
             .entity_mut(entity)
@@ -1543,22 +1393,14 @@ mod tests {
         app.update();
         app.update();
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "water");
-
-        let attached = app
-            .world()
-            .entity(entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, water_pt);
+        assert_eq!(attached_to(&app, entity), water_pt);
     }
 
     #[test]
     fn chance_mutation_respects_tick_rate() {
         let mut app = create_test_app();
-        app.world_mut().spawn(ParticleType::new("sand"));
-        app.world_mut().spawn(ParticleType::new("water"));
+        let sand_pt = app.world_mut().spawn(ParticleType::new("sand")).id();
+        let water_pt = app.world_mut().spawn(ParticleType::new("water")).id();
         app.update();
 
         let position = IVec2::ZERO;
@@ -1569,9 +1411,7 @@ mod tests {
             .insert(ChanceMutation::new("water", 1.0, Duration::from_secs(999)));
         app.update();
         app.update();
-
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "sand");
+        assert_eq!(attached_to(&app, entity), sand_pt);
 
         *app.world_mut()
             .entity_mut(entity)
@@ -1580,12 +1420,11 @@ mod tests {
         app.update();
         app.update();
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "water");
+        assert_eq!(attached_to(&app, entity), water_pt);
     }
 
     #[test]
-    fn chance_mutation_unregistered_target_reverts() {
+    fn chance_mutation_unregistered_target_is_skipped() {
         let mut app = create_test_app();
         let sand_pt = app.world_mut().spawn(ParticleType::new("sand")).id();
         app.update();
@@ -1600,18 +1439,11 @@ mod tests {
         app.update();
         app.update();
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
         assert_eq!(
-            particle.name, "sand",
-            "Mutation to an unregistered type should be reverted"
+            attached_to(&app, entity),
+            sand_pt,
+            "Mutation to an unregistered type is silently skipped"
         );
-
-        let attached = app
-            .world()
-            .entity(entity)
-            .get::<AttachedToParticleType>()
-            .unwrap();
-        assert_eq!(attached.0, sand_pt);
     }
 
     #[test]
@@ -1621,7 +1453,7 @@ mod tests {
             ParticleType::new("sand"),
             ChanceMutation::new("water", 1.0, Duration::ZERO),
         ));
-        app.world_mut().spawn(ParticleType::new("water"));
+        let water_pt = app.world_mut().spawn(ParticleType::new("water")).id();
         app.update();
 
         let position = IVec2::ZERO;
@@ -1635,7 +1467,6 @@ mod tests {
         app.update();
         app.update();
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "water");
+        assert_eq!(attached_to(&app, entity), water_pt);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //!     for x in 0..10 {
 //!         for y in 0..10 {
 //!             writer.write(SpawnParticleSignal::new(
-//!                 Particle::new("Sand"),
+//!                 "Sand",
 //!                 IVec2::new(x, y),
 //!             ));
 //!         }
@@ -106,8 +106,10 @@
 //! [`ParticleType`] is inserted on an entity, it becomes a point of synchronization for all
 //! [`Particle`] entities of the same identifier.
 //!
-//! The [`ParticleType::name`] and [`Particle::name`] fields are used to associate particles with
-//! their parents.
+//! Particles are introduced into the simulation by writing a [`SpawnParticleSignal`] — direct
+//! `commands.spawn(...)` of a [`Particle`] is not supported. Each spawned particle receives an
+//! [`AttachedToParticleType`] reference pointing at its parent [`ParticleType`] entity, which is
+//! the canonical source for the particle's type identity.
 //!
 //! `bfs` provides several components that add behaviors particle types. Inserting any of the
 //! components from the table below on a [`ParticleType`] entity will influence its child

--- a/src/persistence/chunks/load.rs
+++ b/src/persistence/chunks/load.rs
@@ -8,7 +8,7 @@ use super::resources::{
     ChunkLoadResult, ChunkPersistenceError, ParticlePersistenceConfig, ParticlePersistenceState,
     PendingChunkData, PendingLoadTasks, PendingSaveTasks, chunk_file_path, chunk_png_path,
 };
-use crate::core::{ChunkIndex, ChunkLoadingState, Particle, ParticleTypeRegistry};
+use crate::core::{ChunkIndex, ChunkLoadingState, ParticleTypeRegistry, SpawnParticleSignal};
 use crate::render::ForceColor;
 pub(super) struct LoadPlugin;
 
@@ -155,7 +155,7 @@ fn spawn_loaded_particles(
     chunk_index: Res<ChunkIndex>,
     registry: Res<ParticleTypeRegistry>,
     mut pending: ResMut<PendingLoadTasks>,
-    mut commands: Commands,
+    mut spawn_writer: MessageWriter<SpawnParticleSignal>,
 ) {
     let chunk_size = chunk_index.chunk_size() as i32;
 
@@ -176,14 +176,6 @@ fn spawn_loaded_particles(
         );
 
         for particle_data in &chunk_data.particles {
-            let transform = Transform::from_xyz(
-                particle_data.position.x as f32,
-                particle_data.position.y as f32,
-                0.,
-            );
-
-            let particle = Particle::from_string(particle_data.name.clone());
-
             let force_color = chunk_data.image.as_ref().and_then(|img| {
                 let px = (particle_data.position.x - chunk_min.x) as u32;
                 let py = (chunk_size - 1 - (particle_data.position.y - chunk_min.y)) as u32;
@@ -201,11 +193,18 @@ fn spawn_loaded_particles(
                 }
             });
 
-            if let Some(color) = force_color {
-                commands.spawn((particle, transform, color));
+            let signal = SpawnParticleSignal::overwrite_existing(
+                particle_data.name.clone(),
+                particle_data.position,
+            );
+            let signal = if let Some(color) = force_color {
+                signal.with_on_spawn(move |cmd| {
+                    cmd.insert(color);
+                })
             } else {
-                commands.spawn((particle, transform));
-            }
+                signal
+            };
+            spawn_writer.write(signal);
         }
 
         debug!(

--- a/src/persistence/chunks/save.rs
+++ b/src/persistence/chunks/save.rs
@@ -9,7 +9,8 @@ use super::resources::{
     chunk_png_path,
 };
 use crate::core::{
-    ChunkIndex, ChunkLoadingState, ChunkSystems, GridPosition, Particle, ParticleMap,
+    AttachedToParticleType, ChunkIndex, ChunkLoadingState, ChunkSystems, GridPosition, Particle,
+    ParticleMap, ParticleType,
 };
 use crate::persistence::bfs::ParticleData as BfsParticleData;
 use crate::render::{ChunkRenderingConfig, ParticleColor, extract_chunk_image};
@@ -53,7 +54,8 @@ fn persist_unloaded_chunks(
     loading_state: Res<ChunkLoadingState>,
     chunk_index: Res<ChunkIndex>,
     mut pending_tasks: ResMut<PendingSaveTasks>,
-    particle_query: Query<(Entity, &Particle, &GridPosition)>,
+    particle_query: Query<(Entity, &AttachedToParticleType, &GridPosition), With<Particle>>,
+    type_query: Query<&ParticleType>,
     color_query: Query<&ParticleColor, With<Particle>>,
 ) {
     if loading_state.unloaded_this_frame.is_empty() {
@@ -86,17 +88,20 @@ fn persist_unloaded_chunks(
         particles_by_chunk.entry(coord).or_default();
     }
 
-    for (entity, particle, grid_pos) in particle_query.iter() {
+    for (entity, attached, grid_pos) in particle_query.iter() {
         let coord = crate::core::ChunkCoord::new(
             grid_pos.0.x.div_euclid(chunk_size),
             grid_pos.0.y.div_euclid(chunk_size),
         );
         if unloaded_coords.contains(&coord) {
+            let Ok(particle_type) = type_query.get(attached.0) else {
+                continue;
+            };
             particles_by_chunk
                 .entry(coord)
                 .or_default()
                 .push(BfsParticleData {
-                    name: particle.name.to_string(),
+                    name: particle_type.name.to_string(),
                     position: grid_pos.0,
                 });
             if let Ok(pc) = color_query.get(entity) {
@@ -162,7 +167,8 @@ fn msgr_save_all_chunks(
     map: Res<ParticleMap>,
     chunk_index: Res<ChunkIndex>,
     pending_tasks: ResMut<PendingSaveTasks>,
-    particle_query: Query<(&Particle, &GridPosition)>,
+    particle_query: Query<(&AttachedToParticleType, &GridPosition), With<Particle>>,
+    type_query: Query<&ParticleType>,
     color_query: Query<&ParticleColor, With<Particle>>,
 ) {
     if reader.read().next().is_none() {
@@ -175,6 +181,7 @@ fn msgr_save_all_chunks(
         &chunk_index,
         pending_tasks,
         &particle_query,
+        &type_query,
         &color_query,
     );
 }
@@ -187,7 +194,8 @@ fn on_save_all_chunks(
     map: Res<ParticleMap>,
     chunk_index: Res<ChunkIndex>,
     pending_tasks: ResMut<PendingSaveTasks>,
-    particle_query: Query<(&Particle, &GridPosition)>,
+    particle_query: Query<(&AttachedToParticleType, &GridPosition), With<Particle>>,
+    type_query: Query<&ParticleType>,
     color_query: Query<&ParticleColor, With<Particle>>,
 ) {
     save_all_chunks_impl(
@@ -197,6 +205,7 @@ fn on_save_all_chunks(
         &chunk_index,
         pending_tasks,
         &particle_query,
+        &type_query,
         &color_query,
     );
 }
@@ -208,7 +217,8 @@ fn save_all_chunks_impl(
     map: &ParticleMap,
     chunk_index: &ChunkIndex,
     mut pending_tasks: ResMut<PendingSaveTasks>,
-    particle_query: &Query<(&Particle, &GridPosition)>,
+    particle_query: &Query<(&AttachedToParticleType, &GridPosition), With<Particle>>,
+    type_query: &Query<&ParticleType>,
     color_query: &Query<&ParticleColor, With<Particle>>,
 ) {
     debug!(
@@ -234,10 +244,11 @@ fn save_all_chunks_impl(
             for x in min.x..=max.x {
                 let pos = IVec2::new(x, y);
                 if let Ok(Some(entity)) = map.get_copied(pos)
-                    && let Ok((particle, grid_pos)) = particle_query.get(entity)
+                    && let Ok((attached, grid_pos)) = particle_query.get(entity)
+                    && let Ok(particle_type) = type_query.get(attached.0)
                 {
                     particles_to_save.push(BfsParticleData {
-                        name: particle.name.to_string(),
+                        name: particle_type.name.to_string(),
                         position: grid_pos.0,
                     });
                 }

--- a/src/physics/dynamic.rs
+++ b/src/physics/dynamic.rs
@@ -1011,7 +1011,7 @@ mod tests {
         let pos = IVec2::new(11, 10);
         let entity = spawn_particle(&mut app, "sand", pos);
 
-        let particle_before = app.world().entity(entity).get::<Particle>().cloned();
+        let particle_before = app.world().entity(entity).get::<Particle>().copied();
         let attached_before = app
             .world()
             .entity(entity)
@@ -1022,7 +1022,7 @@ mod tests {
         app.update();
 
         let entity_ref = app.world().entity(entity);
-        assert_eq!(entity_ref.get::<Particle>().cloned(), particle_before);
+        assert_eq!(entity_ref.get::<Particle>().copied(), particle_before);
         assert_eq!(
             entity_ref.get::<AttachedToParticleType>().map(|a| a.0),
             attached_before,

--- a/src/physics/dynamic.rs
+++ b/src/physics/dynamic.rs
@@ -507,7 +507,7 @@ mod tests {
 
     fn spawn_particle(app: &mut App, name: &'static str, position: IVec2) -> Entity {
         app.world_mut()
-            .write_message(SpawnParticleSignal::new(Particle::new(name), position));
+            .write_message(SpawnParticleSignal::new(name, position));
         app.update();
 
         app.world()
@@ -645,8 +645,17 @@ mod tests {
         send_promote(&mut app, entity);
         app.update();
 
-        let particle = app.world().entity(entity).get::<Particle>().unwrap();
-        assert_eq!(particle.name, "sand");
+        let attached = app
+            .world()
+            .entity(entity)
+            .get::<AttachedToParticleType>()
+            .unwrap();
+        let parent_type = app
+            .world()
+            .entity(attached.0)
+            .get::<ParticleType>()
+            .unwrap();
+        assert_eq!(parent_type.name, "sand");
     }
 
     // ---- rejoin_dynamic_rigid_bodies ----
@@ -905,14 +914,17 @@ mod tests {
         assert_eq!(count_after_rejoin, initial_count);
 
         assert!(app.world().entities().contains(dynamic_entity));
-        assert_eq!(
-            app.world()
-                .entity(dynamic_entity)
-                .get::<Particle>()
-                .unwrap()
-                .name,
-            "sand"
-        );
+        let attached = app
+            .world()
+            .entity(dynamic_entity)
+            .get::<AttachedToParticleType>()
+            .unwrap();
+        let parent_type = app
+            .world()
+            .entity(attached.0)
+            .get::<ParticleType>()
+            .unwrap();
+        assert_eq!(parent_type.name, "sand");
     }
 
     #[test]

--- a/src/reactions/contact.rs
+++ b/src/reactions/contact.rs
@@ -45,15 +45,15 @@ impl Plugin for ContactPlugin {
 /// ```no_run
 /// use bevy::prelude::*;
 /// use bevy_falling_sand::reactions::{ContactReaction, ContactRule, Consumes};
-/// use bevy_falling_sand::core::{Particle, ParticleType};
+/// use bevy_falling_sand::core::ParticleType;
 ///
 /// fn setup(mut commands: Commands) {
 ///     commands.spawn((
 ///         ParticleType::new("Wood"),
 ///         ContactReaction {
 ///             rules: vec![ContactRule {
-///                 target: Particle::new("Lava"),
-///                 becomes: Particle::new("Fire"),
+///                 target: ParticleType::new("Lava"),
+///                 becomes: ParticleType::new("Fire"),
 ///                 chance: 0.8,
 ///                 radius: 1.0,
 ///                 consumes: Consumes::Source,
@@ -72,15 +72,20 @@ pub struct ContactReaction {
 
 /// A single contact reaction rule.
 ///
+/// `target` and `becomes` carry [`ParticleType`] values purely as name carriers — they're
+/// looked up against [`ParticleTypeRegistry`] when the rule is resolved. Use
+/// `ParticleType::new("Lava")` for static literals or `"Lava".into()` via the
+/// `From<&'static str>` impl.
+///
 /// # Examples
 ///
 /// ```
-/// use bevy_falling_sand::core::Particle;
+/// use bevy_falling_sand::core::ParticleType;
 /// use bevy_falling_sand::reactions::{ContactRule, Consumes};
 ///
 /// let rule = ContactRule {
-///     target: Particle::new("Water"),
-///     becomes: Particle::new("Steam"),
+///     target: ParticleType::new("Water"),
+///     becomes: ParticleType::new("Steam"),
 ///     chance: 0.5,
 ///     radius: 1.0,
 ///     consumes: Consumes::Target,
@@ -90,10 +95,10 @@ pub struct ContactReaction {
 /// ```
 #[derive(Clone, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 pub struct ContactRule {
-    /// The particle type to react with on contact.
-    pub target: Particle,
-    /// The particle type the reacting particle becomes.
-    pub becomes: Particle,
+    /// [`ParticleType`] this rule reacts with on contact.
+    pub target: ParticleType,
+    /// [`ParticleType`] produced by the reaction.
+    pub becomes: ParticleType,
     /// Probability per contact per frame (0.0 to 1.0).
     pub chance: f64,
     /// The radius within which to check for the target particle.
@@ -120,8 +125,8 @@ pub enum Consumes {
 impl Default for ContactRule {
     fn default() -> Self {
         Self {
-            target: Particle::default(),
-            becomes: Particle::default(),
+            target: ParticleType::default(),
+            becomes: ParticleType::default(),
             chance: 0.0,
             radius: 1.0,
             consumes: Consumes::default(),
@@ -145,7 +150,7 @@ pub(super) struct ResolvedContactReaction {
 #[derive(Clone, Debug)]
 pub(super) struct ResolvedContactRule {
     pub(crate) target_type: Entity,
-    pub(crate) becomes: Particle,
+    pub(crate) becomes: ParticleType,
     pub(crate) chance: f64,
     pub(crate) radius: f32,
     pub(crate) consumes: Consumes,

--- a/src/reactions/fire.rs
+++ b/src/reactions/fire.rs
@@ -23,7 +23,7 @@ use crate::{
 /// already [`Burning`]) will be ignited based on the neighbor's [`Flammable::chance_to_ignite`]
 /// probability.
 ///
-/// Can be placed on a [`ParticleType`](crate::ParticleType) for permanent fire sources (e.g. lava), or added
+/// Can be placed on a [`ParticleType`] for permanent fire sources (e.g. lava), or added
 /// dynamically when a particle ignites via [`Flammable::spreads_fire`].
 ///
 /// # Examples

--- a/src/reactions/fire.rs
+++ b/src/reactions/fire.rs
@@ -10,8 +10,8 @@ use super::ReactionRng;
 use crate::{
     core::{
         ChanceLifetime, ChunkDirtyState, ChunkIndex, DespawnParticleSignal, GridPosition, Particle,
-        ParticleMap, ParticleRng, ParticleSyncExt, ParticleSystems, ParticleTypeRegistry,
-        SpawnParticleSignal,
+        ParticleMap, ParticleRng, ParticleSyncExt, ParticleSystems, ParticleType,
+        ParticleTypeRegistry, SpawnParticleSignal,
     },
     movement::Movement,
 };
@@ -290,7 +290,7 @@ impl Burning {
 /// use bevy_falling_sand::core::Particle;
 /// use bevy_falling_sand::reactions::BurnProduct;
 ///
-/// let product = BurnProduct::new(Particle::new("Smoke"), 0.1);
+/// let product = BurnProduct::new("Smoke", 0.1);
 /// assert_eq!(product.produces.name, "Smoke");
 /// assert_eq!(product.chance_to_produce, 0.1);
 /// ```
@@ -298,28 +298,30 @@ impl Burning {
 #[reflect(Component)]
 #[type_path = "bfs_reactions::particle"]
 pub struct BurnProduct {
-    /// What the particle will produce when the reaction occurs.
-    pub produces: Particle,
+    /// [`ParticleType`] produced when the reaction occurs.
+    pub produces: ParticleType,
     /// The chance the reaction will occur per frame.
     pub chance_to_produce: f64,
 }
 
 impl BurnProduct {
-    /// Initialize a new `BurnProduct` with a specific particle and chance to produce it.
+    /// Initialize a new `BurnProduct` from a particle type and a per-frame chance.
+    ///
+    /// Accepts anything convertible into [`ParticleType`] — `&'static str` literals, owned
+    /// `String`s, and `ParticleType` values all work.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bevy_falling_sand::core::Particle;
     /// use bevy_falling_sand::reactions::BurnProduct;
     ///
-    /// let product = BurnProduct::new(Particle::new("Ash"), 0.05);
+    /// let product = BurnProduct::new("Ash", 0.05);
     /// assert_eq!(product.chance_to_produce, 0.05);
     /// ```
     #[must_use]
-    pub const fn new(produces: Particle, chance_to_produce: f64) -> Self {
+    pub fn new(produces: impl Into<ParticleType>, chance_to_produce: f64) -> Self {
         Self {
-            produces,
+            produces: produces.into(),
             chance_to_produce,
         }
     }

--- a/src/render/particle/components.rs
+++ b/src/render/particle/components.rs
@@ -452,7 +452,7 @@ impl ColorProfile {
 /// fn spawn_cyan_particle(mut writer: MessageWriter<SpawnParticleSignal>) {
 ///     let forced = Color::srgba(0.0, 1.0, 1.0, 1.0);
 ///     writer.write(
-///         SpawnParticleSignal::new(Particle::new("Sand"), IVec2::new(5, 5))
+///         SpawnParticleSignal::new("Sand", IVec2::new(5, 5))
 ///             .with_on_spawn(move |cmd| {
 ///                 cmd.insert(ForceColor(forced));
 ///             }),

--- a/src/render/particle/mod.rs
+++ b/src/render/particle/mod.rs
@@ -147,7 +147,7 @@ mod tests {
     use super::*;
     use crate::{
         FallingSandMinimalPlugin,
-        core::{Particle, ParticleType, SpawnParticleSignal},
+        core::{ParticleType, SpawnParticleSignal},
         render::{FallingSandRenderPlugin, ParticleColor},
     };
     use bevy::{asset::AssetPlugin, image::ImagePlugin};
@@ -258,10 +258,7 @@ mod tests {
         for i in 0..5 {
             app.world_mut()
                 .resource_mut::<Messages<SpawnParticleSignal>>()
-                .write(SpawnParticleSignal::new(
-                    Particle::new("TestSequential"),
-                    IVec2::new(i, 0),
-                ));
+                .write(SpawnParticleSignal::new("TestSequential", IVec2::new(i, 0)));
         }
 
         for _ in 0..5 {
@@ -301,10 +298,7 @@ mod tests {
 
         app.world_mut()
             .resource_mut::<Messages<SpawnParticleSignal>>()
-            .write(SpawnParticleSignal::new(
-                Particle::new("TestPalette"),
-                IVec2::new(0, 0),
-            ));
+            .write(SpawnParticleSignal::new("TestPalette", IVec2::new(0, 0)));
 
         for _ in 0..5 {
             app.update();
@@ -341,12 +335,11 @@ mod tests {
         app.world_mut()
             .resource_mut::<Messages<SpawnParticleSignal>>()
             .write(
-                SpawnParticleSignal::new(Particle::new("TestForce"), IVec2::new(0, 0))
-                    .with_on_spawn({
-                        move |cmd| {
-                            cmd.insert(ForceColor(forced));
-                        }
-                    }),
+                SpawnParticleSignal::new("TestForce", IVec2::new(0, 0)).with_on_spawn({
+                    move |cmd| {
+                        cmd.insert(ForceColor(forced));
+                    }
+                }),
             );
 
         for _ in 0..5 {

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -40,7 +40,7 @@ use bevy::asset::{AssetLoader, LoadContext};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{DespawnParticleSignal, Particle, SpawnParticleSignal};
+use crate::core::{DespawnParticleSignal, Particle, ParticleType, SpawnParticleSignal};
 #[cfg(feature = "render")]
 use crate::render::ForceColor;
 
@@ -393,7 +393,7 @@ fn spawn_particles_layer(
         let name = &colors[&rgba];
         write_particle_signals(
             writer,
-            Particle::from(name.to_string()),
+            name.clone().into(),
             positions,
             rgba,
             overwrite_existing,
@@ -405,7 +405,7 @@ fn spawn_particles_layer(
 
 fn write_particle_signals(
     writer: &mut MessageWriter<SpawnParticleSignal>,
-    particle: Particle,
+    particle_type: ParticleType,
     positions: Vec<IVec2>,
     rgba: [u8; 4],
     overwrite_existing: bool,
@@ -434,7 +434,7 @@ fn write_particle_signals(
 
     if overwrite_existing {
         writer.write(decorate(SpawnParticleSignal {
-            particle,
+            particle_type,
             positions,
             overwrite_existing: true,
             on_spawn: None,
@@ -442,7 +442,7 @@ fn write_particle_signals(
     } else {
         for pos in positions {
             writer.write(decorate(SpawnParticleSignal {
-                particle: particle.clone(),
+                particle_type: particle_type.clone(),
                 positions: vec![pos],
                 overwrite_existing: false,
                 on_spawn: None,


### PR DESCRIPTION
`Particle` previously held a name field (`Cow<'static str>`), much like `ParticleType`. This did provide a minor convenience for the public API by allowing users to directly access the name of a particle, but also has the consequence of adding a bunch of unecessary memory allocation  large numbers of particles are being spawned into the world. Users can still access particle names by looking up the associated ParticleType via the AttachedToParticleType(entity) field.

This of course means we also have to remove the
`commands.spawn((Particle::new("foo"), Transform(...)))` pattern, but this only ever existed as a convenience for the API anyway. `SpawnParticleSignal` is and likely always will be the preferred/officially supported method of adding new particles to the simulation.